### PR TITLE
feat(ai-services): Write Action Framework v1

### DIFF
--- a/__tests__/pa-agent-runtime-write-action.test.ts
+++ b/__tests__/pa-agent-runtime-write-action.test.ts
@@ -117,13 +117,30 @@ function makeWriteCapability(
     specOverrides: Partial<PreviewSpec> = {},
 ): WriteActionCapability {
     const previewSpec: PreviewSpec = {
-        target: { path: ".pagelet/foo.md", category: "pagelet-review-note" },
-        contentMarkdown: "# Generated review body",
-        impact: "Creates 1 file in .pagelet/",
-        risk: "None",
-        action: "Create .pagelet/foo.md",
+        operationType: "create-file",
+        actionFamily: "pagelet-review-note",
+        capabilityId: WRITE_TOOL_NAME,
+        target: {
+            kind: "vault-path",
+            displayPath: ".pagelet/foo.md",
+            folder: ".pagelet/",
+            filename: "foo.md",
+        },
+        contentPreview: {
+            format: "markdown",
+            body: "# Generated review body",
+            byteSize: 24,
+        },
+        impact: {
+            usesAiProvider: false,
+            usesAiCredits: false,
+            affectsExternalState: false,
+        },
+        riskNotes: [],
+        confirmCopy: { confirmLabel: "Confirm", cancelLabel: "Cancel" },
         ...specOverrides,
     };
+    const initialTargetPath = previewSpec.target.displayPath;
     return {
         name: WRITE_TOOL_NAME,
         description: "Test write action capability",
@@ -176,12 +193,15 @@ function makeWriteCapability(
         execute: async () => {
             throw new Error("WriteActionCapability.execute must not be called directly (use ActionExecutor)");
         },
+        // Fix #3: synchronous + pure target-path extractor consumed by Gate 1.
+        getTargetPath: ((): WriteActionCapability["getTargetPath"] =>
+            (() => initialTargetPath))(),
         buildPreview: jest.fn(async () => previewSpec) as WriteActionCapability["buildPreview"],
         executeWrite: jest.fn(async () => ({
             status: "ok" as const,
-            observation: { createdPath: previewSpec.target.path },
+            observation: { createdPath: previewSpec.target.displayPath },
             sourceRecords: [],
-            inputSummary: `wrote ${previewSpec.target.path}`,
+            inputSummary: `wrote ${previewSpec.target.displayPath}`,
             sources: [],
         })) as WriteActionCapability["executeWrite"],
         ...overrides,
@@ -493,5 +513,109 @@ describe("PA Agent runtime — Write Action Framework integration (Track A · A3
         expect(capability.buildPreview).not.toHaveBeenCalled();
         expect(capability.executeWrite).not.toHaveBeenCalled();
         expect(harness.events).toHaveLength(0);
+    });
+
+    it("rejects with policy_rejected outcome when PolicyEngine denies the action capability (Fix #2)", async () => {
+        // Chat-runtime PolicyEngine → action capabilities denied at canExecute.
+        const policyDenyHarness = buildReviewModeHarness({
+            policyEngine: new PolicyEngine({ platform: "desktop" }),
+        });
+        const capability = makeWriteCapability();
+        policyDenyHarness.registry.register(capability);
+
+        const baseExecutor = createPaAgentCapabilityToolExecutor({
+            registry: policyDenyHarness.registry,
+            plugin: fakePlugin(),
+            platform: "desktop",
+        });
+        const executor = createWriteActionAwareToolExecutor({
+            baseExecutor,
+            actionExecutor: policyDenyHarness.actionExecutor,
+            registry: policyDenyHarness.registry,
+            plugin: fakePlugin(),
+            platform: "desktop",
+        });
+
+        const result = await executor.execute(buildExecutionInput(WRITE_TOOL_NAME));
+        expect(result.outcome).toBe("policy_rejected");
+        expect(result.metadata?.reason).toBe("policy_denied_capability");
+        expect(capability.buildPreview).not.toHaveBeenCalled();
+        expect(capability.executeWrite).not.toHaveBeenCalled();
+        // Framework debug observer did not emit anything (we short-circuited
+        // before reaching the action executor).
+        expect(policyDenyHarness.events).toHaveLength(0);
+    });
+
+    it("rejects with policy_rejected outcome when allowedToolNames excludes the action (Fix #6)", async () => {
+        const harness = buildReviewModeHarness();
+        const capability = makeWriteCapability();
+        harness.registry.register(capability);
+
+        const baseExecutor = createPaAgentCapabilityToolExecutor({
+            registry: harness.registry,
+            plugin: fakePlugin(),
+            platform: "desktop",
+        });
+        const executor = createWriteActionAwareToolExecutor({
+            baseExecutor,
+            actionExecutor: harness.actionExecutor,
+            registry: harness.registry,
+            plugin: fakePlugin(),
+            platform: "desktop",
+            allowedToolNames: new Set<string>(["something_else"]),
+        });
+
+        const result = await executor.execute(buildExecutionInput(WRITE_TOOL_NAME));
+        expect(result.outcome).toBe("policy_rejected");
+        expect(result.metadata?.reason).toBe("tool_outside_user_requested_scope");
+        expect(capability.buildPreview).not.toHaveBeenCalled();
+        expect(harness.events).toHaveLength(0);
+    });
+
+    it("emits CapabilityUsageEvent (status=invoked) on the success path (Fix #2)", async () => {
+        const usageEvents: Array<{ status: string; capabilityName: string }> = [];
+        const policy = new PolicyEngine({
+            platform: "desktop",
+            runKind: "review",
+            allowWrite: true,
+            allowedActionPermissions: ["local-filesystem-write"],
+        });
+        const registry = new CapabilityRegistry({
+            policyEngine: policy,
+            telemetryEnabled: true,
+            onCapabilityEvent: (event) => {
+                usageEvents.push({ status: event.status, capabilityName: event.capabilityName });
+            },
+        });
+        const capability = makeWriteCapability();
+        registry.register(capability);
+
+        const selfWrite = makeNoopSelfWriteRegistry();
+        const actionExecutor = createActionExecutor({
+            previewRenderer: makeRenderer(["confirmed"]),
+            fsProbe: makeFsProbe({ ".pagelet": true }),
+            selfWrite,
+            debugObserver: makeObserver([]),
+            runIdFactory: () => "run-x",
+            now: () => 1000,
+        });
+        const baseExecutor = createPaAgentCapabilityToolExecutor({
+            registry,
+            plugin: fakePlugin(),
+            platform: "desktop",
+        });
+        const executor = createWriteActionAwareToolExecutor({
+            baseExecutor,
+            actionExecutor,
+            registry,
+            plugin: fakePlugin(),
+            platform: "desktop",
+        });
+        const result = await executor.execute(buildExecutionInput(WRITE_TOOL_NAME));
+        expect(result.outcome).toBe("success");
+        expect(usageEvents).toContainEqual({
+            status: "invoked",
+            capabilityName: WRITE_TOOL_NAME,
+        });
     });
 });

--- a/__tests__/pa-agent-runtime-write-action.test.ts
+++ b/__tests__/pa-agent-runtime-write-action.test.ts
@@ -1,0 +1,497 @@
+/**
+ * Integration test for Write Action Framework v1 wiring into PaAgentRuntime
+ * (Track A · A3 acceptance — see docs/sdd-rollout-plan.md §3.2 + framework
+ * SDD §5.2).
+ *
+ * Goal: exercise the `createWriteActionAwareToolExecutor` seam end-to-end on
+ * top of a real {@link CapabilityRegistry}, real {@link createActionExecutor}
+ * (4 gates), and real {@link createPaAgentCapabilityToolExecutor} (chat-runtime
+ * fallthrough path). Stubs are limited to the things that would otherwise
+ * require Obsidian/UI:
+ *   - PreviewRenderer (returns a queued ConfirmationOutcome list)
+ *   - DebugObserver (collects events for assertion)
+ *   - FsProbe (in-memory exists map)
+ *   - PluginManager (settings + log shim)
+ *
+ * Covers the 4 scenarios listed in the rollout plan + the chat-runtime
+ * passthrough invariant:
+ *   1. Happy path: write-action capability runs through all 4 gates and
+ *      reaches executeWrite; debug emit chain matches the expected sequence.
+ *   2. Reject-at-registration: chat-runtime PolicyEngine defaults reject
+ *      WriteActionCapability at register() time → never reaches executeWrite.
+ *   3. User cancel: confirmation outcome "cancelled" → executeWrite skipped
+ *      and a recoverable_error PaAgentToolExecutionResult is surfaced.
+ *   4. Stale drift: snapshot delta between Gate 2 (capture) and Gate 3
+ *      (re-check) blocks execution → executeWrite never invoked.
+ *   5. Passthrough: `kind="tool"` capabilities still route through the
+ *      base executor (chat tools keep working with framework wired in).
+ */
+
+import { describe, expect, it, jest } from "@jest/globals";
+
+import { CapabilityRegistry } from "../src/ai-services/capability-registry";
+import { PolicyEngine } from "../src/ai-services/policy-engine";
+import {
+    createActionExecutor,
+    createSelfWriteRegistry,
+} from "../src/ai-services/write-action-framework/runtime-integration";
+import type {
+    ActionExecutor,
+    FsProbe,
+    SelfWriteRegistry,
+} from "../src/ai-services/write-action-framework";
+import type {
+    ConfirmationOutcome,
+    DebugEvent,
+    DebugObserver,
+    PreviewSpec,
+    PreviewRenderer,
+    WriteActionCapability,
+} from "../src/ai-services/write-action-framework";
+import { createPaAgentCapabilityToolExecutor } from "../src/ai-services/pa-agent-host-tools";
+import { createWriteActionAwareToolExecutor } from "../src/ai-services/pa-agent-runtime";
+import { createCoreToolCapabilities } from "../src/ai-services/capability-adapter";
+import { createCurrentNoteContextTool } from "../src/ai-services/chat-tools";
+import type {
+    AgentCapability,
+    AgentCapabilityContext,
+    AgentPermissionFuture,
+} from "../src/ai-services/capability-types";
+import type {
+    ChatToolName,
+    ChatToolPermission,
+    ChatToolSourceBoundary,
+} from "../src/ai-services/chat-tool-types";
+import type { SourceRecordKind } from "../src/ai-services/chat-types";
+import type {
+    PaAgentToolCall,
+    PaAgentToolExecutionInput,
+} from "../src/ai-services/pa-agent-loop";
+
+jest.mock("obsidian");
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Stubs
+// ─────────────────────────────────────────────────────────────────────────────
+
+function fakePlugin(settings: Record<string, unknown> = {}): AgentCapabilityContext["plugin"] {
+    return {
+        settings: { debug: false, ...settings },
+        log: () => undefined,
+    } as never;
+}
+
+function makeFsProbe(existsMap: Record<string, boolean> = {}): FsProbe {
+    return {
+        exists: jest.fn(async (path: string) => existsMap[path] ?? false) as FsProbe["exists"],
+    };
+}
+
+function makeObserver(events: DebugEvent[]): DebugObserver {
+    return { emit: (event) => events.push(event) };
+}
+
+function makeRenderer(outcomes: ConfirmationOutcome[]): PreviewRenderer {
+    let i = 0;
+    return {
+        show: jest.fn(async () => {
+            const o = outcomes[i++] ?? "confirmed";
+            return { outcome: o };
+        }) as PreviewRenderer["show"],
+    };
+}
+
+function makeNoopSelfWriteRegistry(): SelfWriteRegistry {
+    // Inject no-op timers so Jest workers exit cleanly (the default
+    // implementation uses real setTimeout which Jest fake timers wouldn't catch).
+    return createSelfWriteRegistry({
+        setTimer: () => ({ id: 1 }),
+        clearTimer: () => undefined,
+    });
+}
+
+const WRITE_TOOL_NAME = "test.write_action" as ChatToolName;
+
+function makeWriteCapability(
+    overrides: Partial<WriteActionCapability> = {},
+    specOverrides: Partial<PreviewSpec> = {},
+): WriteActionCapability {
+    const previewSpec: PreviewSpec = {
+        target: { path: ".pagelet/foo.md", category: "pagelet-review-note" },
+        contentMarkdown: "# Generated review body",
+        impact: "Creates 1 file in .pagelet/",
+        risk: "None",
+        action: "Create .pagelet/foo.md",
+        ...specOverrides,
+    };
+    return {
+        name: WRITE_TOOL_NAME,
+        description: "Test write action capability",
+        inputSchema: { type: "object", properties: {}, required: [], additionalProperties: false },
+        plannerGuidance: [],
+        kind: "action",
+        origin: "core",
+        providerId: "test-provider",
+        permission: "local-filesystem-write" as AgentPermissionFuture,
+        sourceBoundary: "vault",
+        cost: "free",
+        platform: "both",
+        outputBudgetChars: 0,
+        timeoutMs: 30_000,
+        requiresConfirmation: true,
+        executionMode: "sequential",
+        failureBehavior: "recoverable",
+        statusMessageText: "writing",
+        sourceRecordKind: "context-used" as SourceRecordKind,
+        actionFamily: "create-file",
+        targetCategory: "pagelet-review-note",
+        targetConfinement: {
+            allowedRoots: [".pagelet/"],
+            allowedExtensions: [".md"],
+            maxPathLength: 200,
+        },
+        toProviderSchema: () => ({
+            type: "function",
+            function: {
+                name: WRITE_TOOL_NAME,
+                description: "Test write action capability",
+                parameters: { type: "object", properties: {}, required: [], additionalProperties: false },
+            },
+        }),
+        toRegistryDefinition: () => ({
+            name: WRITE_TOOL_NAME,
+            description: "Test write action capability",
+            inputSchema: { type: "object", properties: {}, required: [], additionalProperties: false },
+            plannerGuidance: [],
+            permission: "read-only" as ChatToolPermission,
+            cost: "free",
+            outputBudgetChars: 0,
+            requiresConfirmation: true,
+            failureBehavior: "recoverable",
+            statusMessage: "writing",
+            sourceBoundary: "read-only-tool" as ChatToolSourceBoundary,
+        }),
+        // SDD §3.2: WriteActionCapability.execute MUST throw so accidental
+        // direct calls never bypass the 4 gates.
+        execute: async () => {
+            throw new Error("WriteActionCapability.execute must not be called directly (use ActionExecutor)");
+        },
+        buildPreview: jest.fn(async () => previewSpec) as WriteActionCapability["buildPreview"],
+        executeWrite: jest.fn(async () => ({
+            status: "ok" as const,
+            observation: { createdPath: previewSpec.target.path },
+            sourceRecords: [],
+            inputSummary: `wrote ${previewSpec.target.path}`,
+            sources: [],
+        })) as WriteActionCapability["executeWrite"],
+        ...overrides,
+    };
+}
+
+interface RuntimeTestHarness {
+    registry: CapabilityRegistry;
+    actionExecutor: ActionExecutor;
+    selfWrite: SelfWriteRegistry;
+    events: DebugEvent[];
+}
+
+interface RuntimeHarnessOverrides {
+    policyEngine?: PolicyEngine;
+    renderer?: PreviewRenderer;
+    fsProbe?: FsProbe;
+    now?: () => number;
+}
+
+function buildReviewModeHarness(overrides: RuntimeHarnessOverrides = {}): RuntimeTestHarness {
+    const events: DebugEvent[] = [];
+    const policy =
+        overrides.policyEngine
+        ?? new PolicyEngine({
+            platform: "desktop",
+            runKind: "review",
+            allowWrite: true,
+            allowedActionPermissions: ["local-filesystem-write"],
+        });
+    const registry = new CapabilityRegistry({ policyEngine: policy });
+    const selfWrite = makeNoopSelfWriteRegistry();
+    const actionExecutor = createActionExecutor({
+        previewRenderer: overrides.renderer ?? makeRenderer(["confirmed"]),
+        fsProbe: overrides.fsProbe ?? makeFsProbe({ ".pagelet": true }),
+        selfWrite,
+        debugObserver: makeObserver(events),
+        runIdFactory: () => "run-test",
+        now: overrides.now ?? (() => 1000),
+    });
+    return { registry, actionExecutor, selfWrite, events };
+}
+
+function buildToolCall(
+    name: string,
+    input: Record<string, unknown> = {},
+    overrides: Partial<PaAgentToolCall> = {},
+): PaAgentToolCall {
+    return {
+        type: "toolCall",
+        id: "call-1",
+        index: 0,
+        name: name as ChatToolName,
+        input,
+        ...overrides,
+    } as PaAgentToolCall;
+}
+
+function buildExecutionInput(
+    name: string,
+    input: Record<string, unknown> = {},
+): PaAgentToolExecutionInput {
+    return {
+        runId: "run-1",
+        turnId: "turn-1",
+        turnIndex: 0,
+        userInput: "write a review note",
+        toolCall: buildToolCall(name, input),
+        signal: new AbortController().signal,
+    };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("PA Agent runtime — Write Action Framework integration (Track A · A3)", () => {
+    it("routes kind=action capabilities through the 4-gate ActionExecutor and emits the expected debug chain", async () => {
+        const harness = buildReviewModeHarness();
+        const capability = makeWriteCapability();
+        expect(harness.registry.register(capability)).toBe(true);
+
+        const baseExecutor = createPaAgentCapabilityToolExecutor({
+            registry: harness.registry,
+            plugin: fakePlugin(),
+            platform: "desktop",
+        });
+        const executor = createWriteActionAwareToolExecutor({
+            baseExecutor,
+            actionExecutor: harness.actionExecutor,
+            registry: harness.registry,
+            plugin: fakePlugin(),
+            platform: "desktop",
+        });
+
+        const result = await executor.execute(buildExecutionInput(WRITE_TOOL_NAME));
+
+        // PaAgentLoop sees a success outcome carrying capability metadata.
+        expect(result.outcome).toBe("success");
+        expect(result.metadata?.tool).toBe(WRITE_TOOL_NAME);
+        expect(result.metadata?.ok).toBe(true);
+        expect(result.promptText).toContain(".pagelet/foo.md");
+
+        // Capability hooks executed in the right order.
+        expect(capability.buildPreview).toHaveBeenCalledTimes(1);
+        expect(capability.executeWrite).toHaveBeenCalledTimes(1);
+        // Note: capability.execute must remain untouched (throws on direct call).
+        // Implicitly verified by the test not crashing — the framework never calls it.
+
+        // Debug emit chain: 4 gates + execute.ok in order. We don't assert
+        // payload internals (covered by runtime-integration.spec.ts) — only
+        // sequencing + capabilityId routing here.
+        const types = harness.events.map((e) => e.type);
+        expect(types).toEqual([
+            "gate.target-confinement.ok",
+            "gate.preview.shown",
+            "gate.confirmation.received",
+            "gate.stale-reread.ok",
+            "execute.ok",
+        ]);
+        for (const event of harness.events) {
+            expect(event.capabilityId).toBe(WRITE_TOOL_NAME);
+            expect(event.runId).toBe("run-test");
+            expect(event.turnId).toBe("turn-1");
+        }
+
+        // Self-write registry was marked before executeWrite so the caller's
+        // modify listener (if any) can skip its own ripple.
+        expect(harness.selfWrite.snapshot()).toContain(".pagelet/foo.md");
+    });
+
+    it("rejects WriteActionCapability registration when PolicyEngine is in chat runtime defaults", () => {
+        // Chat runtime default: runKind=chat, allowWrite=false → kind=action rejected at register().
+        const chatPolicy = new PolicyEngine({ platform: "desktop" });
+        const registry = new CapabilityRegistry({ policyEngine: chatPolicy });
+        const capability = makeWriteCapability();
+
+        // register() returns true (capability is recorded for diagnostics) but
+        // policy decision is logged. The functional contract we care about is
+        // that ANY attempt to execute it via the registry pipeline yields a
+        // policy-rejected ChatToolResult — preserving chat-runtime safety.
+        registry.register(capability);
+        const diagnostics = registry.listDiagnostics();
+        expect(diagnostics.some((d) => d.capabilityName === WRITE_TOOL_NAME && d.type === "policy")).toBe(true);
+
+        // listDefinitions excludes kind=action even when registered.
+        const definitions = registry.listDefinitions();
+        expect(definitions.find((d) => d.name === WRITE_TOOL_NAME)).toBeUndefined();
+    });
+
+    it("does not reach executeWrite when the user cancels the preview modal", async () => {
+        const harness = buildReviewModeHarness({
+            renderer: makeRenderer(["cancelled"]),
+        });
+        const capability = makeWriteCapability();
+        harness.registry.register(capability);
+
+        const baseExecutor = createPaAgentCapabilityToolExecutor({
+            registry: harness.registry,
+            plugin: fakePlugin(),
+            platform: "desktop",
+        });
+        const executor = createWriteActionAwareToolExecutor({
+            baseExecutor,
+            actionExecutor: harness.actionExecutor,
+            registry: harness.registry,
+            plugin: fakePlugin(),
+            platform: "desktop",
+        });
+
+        const result = await executor.execute(buildExecutionInput(WRITE_TOOL_NAME));
+
+        // PaAgentLoop sees recoverable_error so the model can self-correct.
+        expect(result.outcome).toBe("recoverable_error");
+        expect(result.metadata?.ok).toBe(false);
+        expect(capability.executeWrite).not.toHaveBeenCalled();
+
+        // Debug emit chain stops after confirmation.received and never reaches
+        // stale-reread or execute.
+        const types = harness.events.map((e) => e.type);
+        expect(types).toEqual([
+            "gate.target-confinement.ok",
+            "gate.preview.shown",
+            "gate.confirmation.received",
+        ]);
+    });
+
+    it("blocks execution and emits stale-reread.drift when the snapshot changes between Gate 2 and Gate 3", async () => {
+        // fsProbe returns different `exists` results across calls to simulate
+        // a concurrent file creation while the preview was shown.
+        let calls = 0;
+        const probe: FsProbe = {
+            exists: jest.fn(async (path: string) => {
+                if (path === ".pagelet") return true;
+                if (path === ".pagelet/foo.md") {
+                    calls += 1;
+                    // 1st call (Gate 1 collision check) — file missing.
+                    // 2nd call (Gate 2 snapshot) — still missing.
+                    // 3rd call (Gate 3 re-check) — file appeared → drift.
+                    return calls >= 3;
+                }
+                return false;
+            }) as FsProbe["exists"],
+        };
+        const harness = buildReviewModeHarness({ fsProbe: probe });
+        const capability = makeWriteCapability();
+        harness.registry.register(capability);
+
+        const baseExecutor = createPaAgentCapabilityToolExecutor({
+            registry: harness.registry,
+            plugin: fakePlugin(),
+            platform: "desktop",
+        });
+        const executor = createWriteActionAwareToolExecutor({
+            baseExecutor,
+            actionExecutor: harness.actionExecutor,
+            registry: harness.registry,
+            plugin: fakePlugin(),
+            platform: "desktop",
+        });
+
+        const result = await executor.execute(buildExecutionInput(WRITE_TOOL_NAME));
+
+        expect(result.outcome).toBe("recoverable_error");
+        expect(capability.executeWrite).not.toHaveBeenCalled();
+        const types = harness.events.map((e) => e.type);
+        expect(types).toContain("gate.stale-reread.drift");
+        expect(types).not.toContain("execute.ok");
+    });
+
+    it("passes kind=tool capabilities through to the base chat-runtime executor unchanged", async () => {
+        const harness = buildReviewModeHarness();
+        // Register a real read-only chat tool alongside the write-action
+        // capability to prove dispatch is per-capability. We use
+        // get_current_note_context because it touches a Jest-mocked
+        // workspace gracefully (no active note → it returns its own
+        // recoverable_error result rather than crashing), which is enough
+        // to verify that the base executor — not the framework — handled it.
+        const [currentNoteCap] = createCoreToolCapabilities([createCurrentNoteContextTool()]);
+        if (!currentNoteCap) throw new Error("expected current-note capability");
+        harness.registry.registerMany([currentNoteCap]);
+        harness.registry.register(makeWriteCapability());
+
+        const baseExecutor = createPaAgentCapabilityToolExecutor({
+            registry: harness.registry,
+            plugin: fakePlugin({ app: { workspace: {} } }),
+            platform: "desktop",
+        });
+        const executor = createWriteActionAwareToolExecutor({
+            baseExecutor,
+            actionExecutor: harness.actionExecutor,
+            registry: harness.registry,
+            plugin: fakePlugin({ app: { workspace: {} } }),
+            platform: "desktop",
+        });
+
+        // Spy on the base executor to confirm dispatch routing.
+        const baseSpy = jest.spyOn(baseExecutor, "execute");
+
+        // kind=tool path: base executor is called regardless of result content.
+        await executor.execute(
+            buildExecutionInput("get_current_note_context", { mode: "metadata" }),
+        );
+        expect(baseSpy).toHaveBeenCalledTimes(1);
+
+        // Action capability still routes through ActionExecutor — base executor
+        // is NOT invoked again for the write-action call.
+        baseSpy.mockClear();
+        const actionResult = await executor.execute(buildExecutionInput(WRITE_TOOL_NAME));
+        expect(actionResult.outcome).toBe("success");
+        expect(baseSpy).not.toHaveBeenCalled();
+
+        // No write-action debug events leaked into the kind=tool call (the
+        // first invocation should not have populated the observer; the second
+        // populated all 5 events).
+        expect(harness.events.filter((e) => e.capabilityId === "get_current_note_context")).toHaveLength(0);
+        expect(harness.events.filter((e) => e.capabilityId === WRITE_TOOL_NAME).length).toBeGreaterThan(0);
+    });
+
+    it("returns schema_invalid before invoking ActionExecutor when prepareAndValidate fails", async () => {
+        const harness = buildReviewModeHarness();
+        const capability = makeWriteCapability({
+            // Force a validation failure. The chat-runtime executor consumes
+            // schema_invalid before reaching execute() — the action-aware
+            // wrapper must preserve the same ordering.
+            prepareAndValidate: ((): AgentCapability["prepareAndValidate"] => () => ({
+                ok: false,
+                error: new Error("invalid path"),
+            }))(),
+        });
+        harness.registry.register(capability);
+
+        const baseExecutor = createPaAgentCapabilityToolExecutor({
+            registry: harness.registry,
+            plugin: fakePlugin(),
+            platform: "desktop",
+        });
+        const executor = createWriteActionAwareToolExecutor({
+            baseExecutor,
+            actionExecutor: harness.actionExecutor,
+            registry: harness.registry,
+            plugin: fakePlugin(),
+            platform: "desktop",
+        });
+
+        const result = await executor.execute(buildExecutionInput(WRITE_TOOL_NAME, { path: "bad" }));
+        expect(result.outcome).toBe("schema_invalid");
+        expect(result.metadata?.reason).toBe("input_validation_failed");
+        expect(capability.buildPreview).not.toHaveBeenCalled();
+        expect(capability.executeWrite).not.toHaveBeenCalled();
+        expect(harness.events).toHaveLength(0);
+    });
+});

--- a/__tests__/policy-engine.test.ts
+++ b/__tests__/policy-engine.test.ts
@@ -1,0 +1,304 @@
+import { describe, expect, it } from "@jest/globals";
+
+import type {
+    AgentCapability,
+    AgentPermission,
+    AgentPermissionFuture,
+} from "../src/ai-services/capability-types";
+import { PolicyEngine } from "../src/ai-services/policy-engine";
+
+/**
+ * Builds a minimal `AgentCapability` for PolicyEngine unit tests. Only fields
+ * that PolicyEngine.evaluate inspects (kind, permission, requiresConfirmation,
+ * failureBehavior, platform) are exercised here; the rest are inert stubs so
+ * tests stay focused on the decision matrix in framework SDD §4.
+ */
+function buildCapability(overrides: Partial<AgentCapability>): AgentCapability {
+    const base: AgentCapability = {
+        name: "search_vault_metadata",
+        description: "test capability",
+        inputSchema: { type: "object", properties: {}, required: [], additionalProperties: false },
+        plannerGuidance: [],
+        kind: "tool",
+        origin: "core",
+        providerId: "test-provider",
+        permission: "read-only",
+        sourceBoundary: "read-only-tool",
+        cost: "free",
+        platform: "both",
+        outputBudgetChars: 6000,
+        timeoutMs: 30_000,
+        requiresConfirmation: false,
+        failureBehavior: "recoverable",
+        statusMessageText: "running",
+        sourceRecordKind: "context-used",
+        toProviderSchema: () => ({
+            type: "function",
+            function: {
+                name: "search_vault_metadata",
+                description: "test capability",
+                parameters: {
+                    type: "object",
+                    properties: {},
+                    required: [],
+                    additionalProperties: false,
+                },
+            },
+        }),
+        toRegistryDefinition: () => ({
+            name: "search_vault_metadata",
+            description: "test capability",
+            inputSchema: { type: "object", properties: {}, required: [], additionalProperties: false },
+            plannerGuidance: [],
+            permission: "read-only",
+            cost: "free",
+            outputBudgetChars: 6000,
+            requiresConfirmation: false,
+            failureBehavior: "recoverable",
+            statusMessage: "running",
+            sourceBoundary: "read-only-tool",
+        }),
+        execute: async () => ({
+            status: "ok",
+            observation: null,
+            sourceRecords: [],
+            inputSummary: "",
+            sources: [],
+        }),
+    };
+    return { ...base, ...overrides };
+}
+
+describe("PolicyEngine decision matrix (framework SDD §4.2)", () => {
+    // Row 1: tool + read-only on chat runtime → allowed
+    it("row 1: tool/read-only on chat runtime → allowed", () => {
+        const engine = new PolicyEngine();
+        const capability = buildCapability({ kind: "tool", permission: "read-only" });
+        expect(engine.canExport(capability)).toEqual({ allowed: true });
+    });
+
+    // Row 2: tool + network-read on chat runtime → allowed
+    it("row 2: tool/network-read on chat runtime → allowed", () => {
+        const engine = new PolicyEngine();
+        const capability = buildCapability({ kind: "tool", permission: "network-read" });
+        expect(engine.canExport(capability)).toEqual({ allowed: true });
+    });
+
+    // Row 3: tool + write on chat runtime → denied (non-action write permission rejected)
+    it("row 3: tool/write on chat runtime → denied (permission not in chat allowlist)", () => {
+        const engine = new PolicyEngine();
+        const capability = buildCapability({
+            kind: "tool",
+            permission: "write" as AgentPermission,
+        });
+        const decision = engine.canExport(capability);
+        expect(decision.allowed).toBe(false);
+        expect(decision.reason).toMatch(/permission write is not allowed/);
+    });
+
+    // Row 4: action + write on chat runtime (allowWrite=false) → denied
+    it("row 4: action/write on chat runtime (allowWrite=false) → denied", () => {
+        const engine = new PolicyEngine();
+        const capability = buildCapability({
+            kind: "action",
+            permission: "write" as AgentPermission,
+            requiresConfirmation: true,
+        });
+        const decision = engine.canExport(capability);
+        expect(decision.allowed).toBe(false);
+        expect(decision.reason).toMatch(/action capabilities require/);
+    });
+
+    // Row 5: action + write + review + allowWrite=true + allowlist=[write] → allowed
+    it('row 5: action/write on review runtime with allowlist=["write"] → allowed', () => {
+        const engine = new PolicyEngine({
+            runKind: "review",
+            allowWrite: true,
+            allowedActionPermissions: ["write"],
+        });
+        const capability = buildCapability({
+            kind: "action",
+            permission: "write" as AgentPermission,
+            requiresConfirmation: true,
+        });
+        expect(engine.canExport(capability)).toEqual({ allowed: true });
+    });
+
+    // Row 6: action + write + review + allowWrite=true + allowlist=[] → denied (allowlist rejects)
+    it("row 6: action/write on review runtime with empty allowlist → denied", () => {
+        const engine = new PolicyEngine({
+            runKind: "review",
+            allowWrite: true,
+            allowedActionPermissions: [],
+        });
+        const capability = buildCapability({
+            kind: "action",
+            permission: "write" as AgentPermission,
+            requiresConfirmation: true,
+        });
+        const decision = engine.canExport(capability);
+        expect(decision.allowed).toBe(false);
+        expect(decision.reason).toMatch(/not in allowlist/);
+    });
+
+    // Row 7: action + local-filesystem-write + review + allowWrite=true + allowlist=[write] → denied
+    it('row 7: action/local-filesystem-write on review runtime with allowlist=["write"] → denied', () => {
+        const engine = new PolicyEngine({
+            runKind: "review",
+            allowWrite: true,
+            allowedActionPermissions: ["write"],
+        });
+        const capability = buildCapability({
+            kind: "action",
+            permission: "local-filesystem-write" as AgentPermission,
+            requiresConfirmation: true,
+        });
+        const decision = engine.canExport(capability);
+        expect(decision.allowed).toBe(false);
+        expect(decision.reason).toMatch(/local-filesystem-write.*not in allowlist/);
+    });
+
+    // Row 8: action + local-filesystem-write + review + allowWrite=true + allowlist=[write, local-filesystem-write] → allowed
+    it("row 8: action/local-filesystem-write on review runtime with matching allowlist → allowed", () => {
+        const engine = new PolicyEngine({
+            runKind: "review",
+            allowWrite: true,
+            allowedActionPermissions: ["write", "local-filesystem-write"],
+        });
+        const capability = buildCapability({
+            kind: "action",
+            permission: "local-filesystem-write" as AgentPermission,
+            requiresConfirmation: true,
+        });
+        expect(engine.canExport(capability)).toEqual({ allowed: true });
+    });
+
+    // Row 9: action + shell + review + allowWrite=true + allowlist=[write] → denied (v1 framework rejects shell)
+    it('row 9: action/shell on review runtime with allowlist=["write"] → denied', () => {
+        const engine = new PolicyEngine({
+            runKind: "review",
+            allowWrite: true,
+            allowedActionPermissions: ["write"],
+        });
+        const capability = buildCapability({
+            kind: "action",
+            permission: "shell" as AgentPermission,
+            requiresConfirmation: true,
+        });
+        const decision = engine.canExport(capability);
+        expect(decision.allowed).toBe(false);
+        expect(decision.reason).toMatch(/shell.*not in allowlist/);
+    });
+});
+
+describe("PolicyEngine chat runtime backward-compat smoke (framework SDD §4.3)", () => {
+    it("default constructor (no options) keeps PA v1 chat-runtime behavior intact", () => {
+        // Pa-agent-runtime.ts:488 calls `new PolicyEngine({ platform: runtimePlatform })`
+        // without runKind/allowWrite/allowedActionPermissions. Behavior MUST equal pre-A1.
+        const engine = new PolicyEngine();
+
+        // PA v1 chat tools: read-only + recoverable + no confirmation + tool → allowed
+        expect(engine.canExport(buildCapability({
+            kind: "tool",
+            permission: "read-only",
+            requiresConfirmation: false,
+            failureBehavior: "recoverable",
+        }))).toEqual({ allowed: true });
+
+        // network-read also OK
+        expect(engine.canExport(buildCapability({
+            kind: "tool",
+            permission: "network-read",
+        }))).toEqual({ allowed: true });
+
+        // action capability rejected (kind=action gate)
+        expect(engine.canExport(buildCapability({
+            kind: "action",
+            permission: "write" as AgentPermission,
+            requiresConfirmation: true,
+        })).allowed).toBe(false);
+
+        // Non-action write rejected (permission gate)
+        expect(engine.canExport(buildCapability({
+            kind: "tool",
+            permission: "write" as AgentPermission,
+        })).allowed).toBe(false);
+
+        // requiresConfirmation=true on a non-action capability → rejected
+        expect(engine.canExport(buildCapability({
+            kind: "tool",
+            permission: "read-only",
+            requiresConfirmation: true,
+        })).allowed).toBe(false);
+
+        // Platform mismatch is still enforced (defaults to desktop)
+        expect(engine.canExport(buildCapability({
+            kind: "tool",
+            permission: "read-only",
+            platform: "mobile",
+        })).allowed).toBe(false);
+    });
+
+    it("review runtime with allowWrite=false equals chat strict mode (action rejected)", () => {
+        const engine = new PolicyEngine({ runKind: "review", allowWrite: false });
+        const capability = buildCapability({
+            kind: "action",
+            permission: "write" as AgentPermission,
+            requiresConfirmation: true,
+        });
+        const decision = engine.canExport(capability);
+        expect(decision.allowed).toBe(false);
+        expect(decision.reason).toMatch(/require runKind="review" AND allowWrite=true/);
+    });
+
+    it("chat runtime with allowWrite=true still rejects action (runKind gate)", () => {
+        // Guards against accidental misconfiguration: even if a future caller passes
+        // allowWrite=true while leaving runKind defaulted to "chat", action must stay denied.
+        const engine = new PolicyEngine({ allowWrite: true, allowedActionPermissions: ["write"] });
+        const capability = buildCapability({
+            kind: "action",
+            permission: "write" as AgentPermission,
+            requiresConfirmation: true,
+        });
+        const decision = engine.canExport(capability);
+        expect(decision.allowed).toBe(false);
+        expect(decision.reason).toMatch(/require runKind="review"/);
+    });
+
+    it("review runtime preserves non-action chat constraints (no confirmation, no write permission)", () => {
+        const engine = new PolicyEngine({
+            runKind: "review",
+            allowWrite: true,
+            allowedActionPermissions: ["write", "local-filesystem-write"],
+        });
+
+        // tool+write still rejected (allowlist only applies to action capabilities)
+        expect(engine.canExport(buildCapability({
+            kind: "tool",
+            permission: "write" as AgentPermission,
+        })).allowed).toBe(false);
+
+        // tool+read-only with requiresConfirmation=true still rejected
+        expect(engine.canExport(buildCapability({
+            kind: "tool",
+            permission: "read-only",
+            requiresConfirmation: true,
+        })).allowed).toBe(false);
+    });
+
+    it("allowedActionPermissions accepts readonly AgentPermissionFuture[] input", () => {
+        // Type-level smoke test: ensures Set<AgentPermission> internal can be seeded from
+        // a readonly AgentPermissionFuture[] without compile errors.
+        const allowlist: readonly AgentPermissionFuture[] = ["write", "local-filesystem-write"] as const;
+        const engine = new PolicyEngine({
+            runKind: "review",
+            allowWrite: true,
+            allowedActionPermissions: allowlist,
+        });
+        expect(engine.canExport(buildCapability({
+            kind: "action",
+            permission: "write" as AgentPermission,
+            requiresConfirmation: true,
+        }))).toEqual({ allowed: true });
+    });
+});

--- a/src/ai-services/capability-registry.ts
+++ b/src/ai-services/capability-registry.ts
@@ -22,7 +22,7 @@ import {
     OBSIDIAN_OPERATIONS_V1A_MAX_OUTPUT_BUDGET_CHARS,
     isObsidianOperationsV1AToolName,
 } from "./chat-tools";
-import { PolicyEngine } from "./policy-engine";
+import { PolicyEngine, type CapabilityPolicyDecision } from "./policy-engine";
 import { getErrorType } from "./agent-utils";
 
 export interface CapabilityRegistryOptions {
@@ -177,6 +177,33 @@ export class CapabilityRegistry {
 
     has(name: string): boolean {
         return Boolean(this.get(name));
+    }
+
+    /**
+     * Policy gate for capability execution. Used by the Write Action Framework
+     * wrapper (`createWriteActionAwareToolExecutor`) to mirror the
+     * chat-runtime semantics already enforced by `this.execute`. Returns a
+     * specific `unregistered capability` decision when the name is unknown so
+     * the wrapper can short-circuit before touching the action executor.
+     */
+    canExecute(name: string): CapabilityPolicyDecision {
+        const capability = this.get(name);
+        if (!capability) {
+            return { allowed: false, reason: "unregistered capability" };
+        }
+        return this.policyEngine.canExecute(capability);
+    }
+
+    /**
+     * Public wrapper around the private telemetry emitter. The Write Action
+     * Framework wrapper records `invoked`/`failed`/`skipped` events for the
+     * action route here so chat-runtime + framework telemetry stay coherent.
+     * Telemetry gating (the `telemetryEnabled` flag) is preserved inside the
+     * private emitter — callers should always invoke this and let the registry
+     * decide whether to forward to the handler.
+     */
+    recordCapabilityEvent(event: CapabilityUsageEvent): void {
+        this.emitCapabilityEvent(event);
     }
 
     /**

--- a/src/ai-services/pa-agent-host-tools.ts
+++ b/src/ai-services/pa-agent-host-tools.ts
@@ -49,7 +49,7 @@ export function createPaAgentCapabilityToolExecutor(
             // CapabilityRegistry.prepareAndValidate runs prepareArguments + validateInput.
             // Failure → schema_invalid outcome → HostPolicy corrective turn + answer-completion failed-only path.
             const toolCall = input.toolCall;
-            if (!isAllowedHostToolCall(toolCall.name, options)) {
+            if (!isAllowedHostToolCall(toolCall.name, options.allowedToolNames, options.blockedToolNames)) {
                 return {
                     outcome: "policy_rejected",
                     promptText: `Tool ${toolCall.name} was skipped because the user limited this request to different available context.`,
@@ -119,9 +119,19 @@ export function createPaAgentCapabilityToolExecutor(
     };
 }
 
-function isAllowedHostToolCall(toolName: string, options: PaAgentCapabilityToolExecutorOptions): boolean {
-    if (options.allowedToolNames && !options.allowedToolNames.has(toolName)) return false;
-    if (options.blockedToolNames?.has(toolName)) return false;
+/**
+ * Tool-name allow/block list gate shared by the chat-runtime executor (this
+ * file) and the action-aware wrapper in `pa-agent-runtime.ts`. Returns `true`
+ * when the call is permitted; `false` triggers a `policy_rejected` outcome
+ * upstream. Both sets are optional — omitting both behaves as "always allow".
+ */
+export function isAllowedHostToolCall(
+    toolName: string,
+    allowedToolNames?: ReadonlySet<string>,
+    blockedToolNames?: ReadonlySet<string>,
+): boolean {
+    if (allowedToolNames && !allowedToolNames.has(toolName)) return false;
+    if (blockedToolNames?.has(toolName)) return false;
     return true;
 }
 

--- a/src/ai-services/pa-agent-runtime.ts
+++ b/src/ai-services/pa-agent-runtime.ts
@@ -45,7 +45,11 @@ import { PolicyEngine, type PolicyEngineOptions } from "./policy-engine";
 import { createAbortError, isAbortError, throwIfAborted } from "./chat-utils";
 import { errorMessage } from "./agent-utils";
 import { SkillContextProvider } from "./skill-context-provider";
-import { chatToolResultToPaAgentToolExecutionResult, createPaAgentCapabilityToolExecutor } from "./pa-agent-host-tools";
+import {
+    chatToolResultToPaAgentToolExecutionResult,
+    createPaAgentCapabilityToolExecutor,
+    isAllowedHostToolCall,
+} from "./pa-agent-host-tools";
 import { extractCanonicalTurnMetadata } from "./pa-agent-history";
 import {
     ConsoleDebugObserver,
@@ -530,6 +534,16 @@ export interface WriteActionAwareToolExecutorOptions {
     plugin: PluginManager;
     platform?: AgentRuntimePlatform;
     onToolRunning?: (tool: string, message: string) => void;
+    /**
+     * Required-capability allowlist passed through from the runtime so the
+     * action route honors the same scope as the chat-runtime executor (Fix #6).
+     */
+    allowedToolNames?: ReadonlySet<string>;
+    /**
+     * Required-capability blocklist passed through from the runtime so the
+     * action route honors the same scope as the chat-runtime executor (Fix #6).
+     */
+    blockedToolNames?: ReadonlySet<string>;
 }
 
 /**
@@ -577,6 +591,42 @@ export function createWriteActionAwareToolExecutor(
                 return options.baseExecutor.execute(input);
             }
             const writeCapability = capability as WriteActionCapability;
+            // Fix #6: honor allowedToolNames/blockedToolNames before any
+            // action-specific work so out-of-scope writes never reach the
+            // framework (matches `createPaAgentCapabilityToolExecutor` semantics).
+            if (!isAllowedHostToolCall(toolCall.name, options.allowedToolNames, options.blockedToolNames)) {
+                return {
+                    outcome: "policy_rejected",
+                    promptText: `Tool ${toolCall.name} was skipped because the user limited this request to different available context.`,
+                    previewText: `Skipped ${toolCall.name}; outside the user-requested context scope.`,
+                    metadata: {
+                        outcome: "policy_rejected",
+                        reason: "tool_outside_user_requested_scope",
+                    },
+                };
+            }
+            // Fix #2: action route MUST consult PolicyEngine.canExecute and
+            // emit CapabilityUsageEvent — same as the chat-runtime executor.
+            const policyDecision = options.registry.canExecute(toolCall.name);
+            if (!policyDecision.allowed) {
+                options.registry.recordCapabilityEvent({
+                    capabilityName: writeCapability.name,
+                    providerId: writeCapability.providerId,
+                    status: "skipped",
+                    durationMs: 0,
+                });
+                return {
+                    outcome: "policy_rejected",
+                    promptText: `Tool ${toolCall.name} was skipped by policy: ${policyDecision.reason ?? "policy rejected"}.`,
+                    previewText: `Skipped ${toolCall.name}; policy rejected.`,
+                    metadata: {
+                        outcome: "policy_rejected",
+                        reason: "policy_denied_capability",
+                        tool: toolCall.name,
+                        policyReason: policyDecision.reason ?? "policy rejected",
+                    },
+                };
+            }
             const preparedResult = options.registry.prepareAndValidate(
                 toolCall.name,
                 toolCall.input,
@@ -602,11 +652,18 @@ export function createWriteActionAwareToolExecutor(
                 signal: input.signal,
                 platform: options.platform ?? "desktop",
             };
+            const startedAt = Date.now();
             const agentResult = await options.actionExecutor.execute(
                 writeCapability,
                 preparedResult.input,
                 ctx,
             );
+            options.registry.recordCapabilityEvent({
+                capabilityName: writeCapability.name,
+                providerId: writeCapability.providerId,
+                status: agentResult.status === "ok" ? "invoked" : "failed",
+                durationMs: Math.max(0, Date.now() - startedAt),
+            });
             const chatToolResult = agentResultToChatToolResult(writeCapability.name, agentResult);
             const canonicalResult = chatToolResultToPaAgentToolExecutionResult(toolCall, chatToolResult);
             const augmentedMetadata = preparedResult.repaired
@@ -815,6 +872,12 @@ export class PaAgentRuntime {
                 onToolRunning: (tool, message) => {
                     options.onStatus?.({ type: "tool-running", tool, message });
                 },
+                ...(toolUseConstraints?.allowedToolNames
+                    ? { allowedToolNames: toolUseConstraints.allowedToolNames }
+                    : {}),
+                ...(toolUseConstraints?.blockedToolNames
+                    ? { blockedToolNames: toolUseConstraints.blockedToolNames }
+                    : {}),
             })
             : baseToolExecutor;
         const loop = new PaAgentLoop({

--- a/src/ai-services/pa-agent-runtime.ts
+++ b/src/ai-services/pa-agent-runtime.ts
@@ -35,16 +35,30 @@ import {
 import { BUNDLED_SKILL_RESOURCES } from "./bundled-skills";
 import { CapabilityRegistry } from "./capability-registry";
 import { createCoreToolCapabilities } from "./capability-adapter";
-import type {
-    AgentRuntimePlatform,
-    CapabilityProvider,
+import {
+    agentResultToChatToolResult,
+    type AgentCapabilityContext,
+    type AgentRuntimePlatform,
+    type CapabilityProvider,
 } from "./capability-types";
-import { PolicyEngine } from "./policy-engine";
+import { PolicyEngine, type PolicyEngineOptions } from "./policy-engine";
 import { createAbortError, isAbortError, throwIfAborted } from "./chat-utils";
 import { errorMessage } from "./agent-utils";
 import { SkillContextProvider } from "./skill-context-provider";
-import { createPaAgentCapabilityToolExecutor } from "./pa-agent-host-tools";
+import { chatToolResultToPaAgentToolExecutionResult, createPaAgentCapabilityToolExecutor } from "./pa-agent-host-tools";
 import { extractCanonicalTurnMetadata } from "./pa-agent-history";
+import {
+    ConsoleDebugObserver,
+    createActionExecutor,
+    createSelfWriteRegistry,
+    NOOP_DEBUG_OBSERVER,
+    type ActionExecutor,
+    type DebugObserver,
+    type FsProbe,
+    type PreviewRenderer,
+    type SelfWriteRegistry,
+    type WriteActionCapability,
+} from "./write-action-framework";
 import {
     createRequiredCapabilityHostPolicy,
     getExplicitlySuppressedRequiredCapabilities,
@@ -58,6 +72,7 @@ import {
     type PaAgentModel,
     type PaAgentModelInput,
     type PaAgentModelStreamChunk,
+    type PaAgentToolExecutor,
 } from "./pa-agent-loop";
 import type {
     AgentEvent,
@@ -111,6 +126,39 @@ export interface PaAgentRuntimeOptions {
     runtimePlatform?: AgentRuntimePlatform;
     additionalCapabilityProviders?: readonly CapabilityProvider[];
     skillContextProvider?: SkillContextProvider | null;
+    /**
+     * Write Action Framework v1 PolicyEngine parameters (SDD §4 + §5.1).
+     *
+     * Omit (chat runtime default) → PolicyEngine stays in strict chat mode
+     * (kind="action" rejected, only read-only/network-read non-action allowed).
+     *
+     * Provide `runKind: "review"` + `allowWrite: true` + an
+     * `allowedActionPermissions` allowlist (e.g., `["local-filesystem-write"]`)
+     * to unlock WriteActionCapability registration — used by Pagelet's
+     * PaReviewRuntime caller.
+     */
+    policyOptions?: Pick<PolicyEngineOptions, "runKind" | "allowWrite" | "allowedActionPermissions">;
+    /**
+     * Write Action Framework v1 runtime wiring (SDD §5.2 + §5.3).
+     *
+     * Omit → the framework is inert; `kind="action"` tool calls fall through
+     * to {@link CapabilityRegistry.execute} which will reject them per
+     * PolicyEngine (default-deny). Chat runtime callers should NOT set this.
+     *
+     * Provide a {@link PreviewRenderer} to enable the 4-gate orchestrator:
+     * toolExecutor dispatches `kind="action"` capabilities through
+     * {@link ActionExecutor} (target-confinement → preview-confirmation →
+     * stale-reread → executeWrite). `fsProbe` enables Gate 1 collision/folder
+     * checks and Gate 3 snapshot drift detection; omit on platforms where the
+     * vault adapter is unreachable. `debugObserver` defaults to
+     * {@link ConsoleDebugObserver} when `plugin.settings.debug` is true,
+     * otherwise {@link NOOP_DEBUG_OBSERVER}.
+     */
+    writeAction?: {
+        previewRenderer: PreviewRenderer;
+        fsProbe?: FsProbe;
+        debugObserver?: DebugObserver;
+    };
 }
 
 type ReadOnlyToolContextAvailability = "available" | "partial" | "unavailable";
@@ -469,6 +517,119 @@ class CanonicalToLegacyEventAdapter {
     }
 }
 
+/**
+ * Options for the Write Action Framework aware tool executor (SDD §5.2).
+ */
+export interface WriteActionAwareToolExecutorOptions {
+    /** Base executor used for `kind="tool"` capabilities (chat-runtime path). */
+    baseExecutor: PaAgentToolExecutor;
+    /** 4-gate orchestrator used for `kind="action"` capabilities. */
+    actionExecutor: ActionExecutor;
+    /** Registry source for capability lookup + prepareAndValidate. */
+    registry: CapabilityRegistry;
+    plugin: PluginManager;
+    platform?: AgentRuntimePlatform;
+    onToolRunning?: (tool: string, message: string) => void;
+}
+
+/**
+ * Wrap the standard chat-runtime tool executor so {@link WriteActionCapability}
+ * calls are routed through the framework's 4-gate {@link ActionExecutor}
+ * instead of {@link CapabilityRegistry.execute}.
+ *
+ * Why a wrapping executor (vs mutating capability.execute as the SDD §5.2
+ * pseudocode suggests): the chat-runtime path in
+ * `createPaAgentCapabilityToolExecutor` already owns input gating
+ * (allowed/blocked names), `prepareAndValidate`, host-tool preflight, and
+ * result conversion. Wrapping at this seam keeps all that logic in one place
+ * and avoids cross-cutting side effects on registered capabilities.
+ *
+ * Routing flow (per tool call):
+ *   1. Tool not in registry, or `kind !== "action"` → delegate to baseExecutor
+ *      verbatim (chat tools, builtin web search, skill context, …).
+ *   2. `kind === "action"`:
+ *      a. Run {@link CapabilityRegistry.prepareAndValidate} to honor
+ *         schema_invalid outcome ordering (matches chat-runtime semantics).
+ *      b. Call `ActionExecutor.execute(capability, input, ctx)` — the
+ *         framework drives the 4 gates + execute + (optional) rollback and
+ *         returns an {@link AgentCapabilityResult}.
+ *      c. Convert through `agentResultToChatToolResult` →
+ *         {@link chatToolResultToPaAgentToolExecutionResult} so the loop sees
+ *         the same `PaAgentToolExecutionResult` shape as a tool call.
+ *
+ * Implements `getExecutionMode` by forwarding to the base executor, which in
+ * turn reads the registry. WriteActionCapability declares
+ * `executionMode: "sequential"` per framework type contract, so the loop's
+ * hybrid dispatch correctly serializes the batch.
+ */
+export function createWriteActionAwareToolExecutor(
+    options: WriteActionAwareToolExecutorOptions,
+): PaAgentToolExecutor {
+    return {
+        getExecutionMode: (toolName: string) => {
+            return options.baseExecutor.getExecutionMode?.(toolName);
+        },
+        execute: async (input) => {
+            const toolCall = input.toolCall;
+            const capability = options.registry.get(toolCall.name);
+            if (!capability || capability.kind !== "action") {
+                // Non-action tool → standard chat-runtime path.
+                return options.baseExecutor.execute(input);
+            }
+            const writeCapability = capability as WriteActionCapability;
+            const preparedResult = options.registry.prepareAndValidate(
+                toolCall.name,
+                toolCall.input,
+                { userInput: input.userInput },
+            );
+            if (!preparedResult.ok) {
+                const message = preparedResult.error.message;
+                return {
+                    outcome: "schema_invalid",
+                    promptText: `Tool ${toolCall.name} input invalid: ${message}. Retry with the correct schema.`,
+                    previewText: `Schema validation failed for ${toolCall.name}.`,
+                    metadata: {
+                        outcome: "schema_invalid",
+                        reason: "input_validation_failed",
+                        tool: toolCall.name,
+                    },
+                };
+            }
+            options.onToolRunning?.(toolCall.name, `Running ${toolCall.name}`);
+            const ctx: AgentCapabilityContext = {
+                plugin: options.plugin,
+                turnId: input.turnId,
+                signal: input.signal,
+                platform: options.platform ?? "desktop",
+            };
+            const agentResult = await options.actionExecutor.execute(
+                writeCapability,
+                preparedResult.input,
+                ctx,
+            );
+            const chatToolResult = agentResultToChatToolResult(writeCapability.name, agentResult);
+            const canonicalResult = chatToolResultToPaAgentToolExecutionResult(toolCall, chatToolResult);
+            const augmentedMetadata = preparedResult.repaired
+                ? {
+                    ...(canonicalResult.metadata ?? {}),
+                    inputRepaired: true,
+                    repairReason: preparedResult.repaired.reason,
+                    originalInputSummary: preparedResult.repaired.originalInputSummary,
+                    originalInputKeys: preparedResult.repaired.originalKeys,
+                }
+                : canonicalResult.metadata;
+            return {
+                ...canonicalResult,
+                metadata: augmentedMetadata,
+                sourceRecords: canonicalResult.sourceRecords?.map((record) => ({
+                    ...record,
+                    turnId: record.turnId ?? input.turnId,
+                })),
+            };
+        },
+    };
+}
+
 export class PaAgentRuntime {
     private readonly plugin: PluginManager;
     private readonly planner: ChatPlanner;
@@ -477,6 +638,15 @@ export class PaAgentRuntime {
     private readonly skillContextProvider: SkillContextProvider | null;
     private skillContextProviderRegistered = false;
     private readonly options: PaAgentRuntimeOptions;
+    /**
+     * Write Action Framework v1 per-runtime singletons (SDD §5.2 + §5.3).
+     * Null when {@link PaAgentRuntimeOptions.writeAction} is omitted (chat
+     * runtime default — framework inert). Owned by the runtime so the TTL
+     * timers in {@link SelfWriteRegistry} share the runtime's lifecycle;
+     * {@link PaAgentRuntime.dispose} clears them on plugin unload.
+     */
+    private readonly selfWriteRegistry: SelfWriteRegistry | null;
+    private readonly actionExecutor: ActionExecutor | null;
 
     constructor(plugin: PluginManager, aiUtils: AIUtils, options: PaAgentRuntimeOptions = {}) {
         this.plugin = plugin;
@@ -485,12 +655,34 @@ export class PaAgentRuntime {
         this.memoryTool = new MemorySearchTool(plugin, aiUtils);
         const runtimePlatform = this.options.runtimePlatform ?? "desktop";
         this.toolRegistry = new CapabilityRegistry({
-            policyEngine: new PolicyEngine({ platform: runtimePlatform }),
+            policyEngine: new PolicyEngine({
+                platform: runtimePlatform,
+                ...options.policyOptions,
+            }),
             telemetryEnabled: this.plugin.settings.shareAnonymousCapabilityUsage === true,
             onCapabilityEvent: (event) => {
                 this.plugin.log("PA capability usage event", event);
             },
         });
+        // Per-runtime Write Action Framework wiring (SDD §5.2 + §5.3). Build
+        // selfWriteRegistry + actionExecutor exactly once when writeAction is
+        // provided so the TTL timers + debug observer share the runtime's
+        // lifetime; chat runtime callers leave both null.
+        if (options.writeAction) {
+            const selfWriteRegistry = createSelfWriteRegistry();
+            this.selfWriteRegistry = selfWriteRegistry;
+            this.actionExecutor = createActionExecutor({
+                previewRenderer: options.writeAction.previewRenderer,
+                ...(options.writeAction.fsProbe ? { fsProbe: options.writeAction.fsProbe } : {}),
+                selfWrite: selfWriteRegistry,
+                debugObserver:
+                    options.writeAction.debugObserver
+                    ?? (plugin.settings.debug ? new ConsoleDebugObserver() : NOOP_DEBUG_OBSERVER),
+            });
+        } else {
+            this.selfWriteRegistry = null;
+            this.actionExecutor = null;
+        }
         const memoryTool = this.memoryTool;
         const coreCapabilities = createCoreToolCapabilities([
             createSearchMemoryTool((input, context) => {
@@ -509,6 +701,15 @@ export class PaAgentRuntime {
         this.skillContextProvider = options.skillContextProvider === null
             ? null
             : options.skillContextProvider ?? new SkillContextProvider(BUNDLED_SKILL_RESOURCES);
+    }
+
+    /**
+     * Release per-runtime resources. MUST be called by the owner (e.g., on
+     * plugin unload) to cancel any pending self-write TTL timers held by the
+     * Write Action Framework. Safe to invoke multiple times.
+     */
+    dispose(): void {
+        this.selfWriteRegistry?.dispose();
     }
 
     async streamTurn(options: PaAgentStreamOptions): Promise<void> {
@@ -586,28 +787,41 @@ export class PaAgentRuntime {
                 });
             },
         };
+        const baseToolExecutor = createPaAgentCapabilityToolExecutor({
+            registry: this.toolRegistry,
+            plugin: this.plugin,
+            platform: this.options.runtimePlatform ?? "desktop",
+            onBeforeVssSearch: () => {
+                options.onStatus?.({ type: "retrieving", query: "memory" });
+            },
+            onToolRunning: (tool, message) => {
+                if (tool === "search_memory") return;
+                options.onStatus?.({ type: "tool-running", tool, message });
+            },
+            ...(toolUseConstraints?.allowedToolNames
+                ? { allowedToolNames: toolUseConstraints.allowedToolNames }
+                : {}),
+            ...(toolUseConstraints?.blockedToolNames
+                ? { blockedToolNames: toolUseConstraints.blockedToolNames }
+                : {}),
+        });
+        const toolExecutor = this.actionExecutor
+            ? createWriteActionAwareToolExecutor({
+                baseExecutor: baseToolExecutor,
+                actionExecutor: this.actionExecutor,
+                registry: this.toolRegistry,
+                plugin: this.plugin,
+                platform: this.options.runtimePlatform ?? "desktop",
+                onToolRunning: (tool, message) => {
+                    options.onStatus?.({ type: "tool-running", tool, message });
+                },
+            })
+            : baseToolExecutor;
         const loop = new PaAgentLoop({
             runId,
             userInput: options.prompt,
             model,
-            toolExecutor: createPaAgentCapabilityToolExecutor({
-                registry: this.toolRegistry,
-                plugin: this.plugin,
-                platform: this.options.runtimePlatform ?? "desktop",
-                onBeforeVssSearch: () => {
-                    options.onStatus?.({ type: "retrieving", query: "memory" });
-                },
-                onToolRunning: (tool, message) => {
-                    if (tool === "search_memory") return;
-                    options.onStatus?.({ type: "tool-running", tool, message });
-                },
-                ...(toolUseConstraints?.allowedToolNames
-                    ? { allowedToolNames: toolUseConstraints.allowedToolNames }
-                    : {}),
-                ...(toolUseConstraints?.blockedToolNames
-                    ? { blockedToolNames: toolUseConstraints.blockedToolNames }
-                    : {}),
-            }),
+            toolExecutor,
             hostPolicy: {
                 afterTurn: requiredCapabilityPolicy.hostPolicy.afterTurn,
             },

--- a/src/ai-services/policy-engine.ts
+++ b/src/ai-services/policy-engine.ts
@@ -1,5 +1,6 @@
 import type {
     AgentCapability,
+    AgentPermission,
     AgentPermissionFuture,
     AgentRuntimePlatform,
 } from "./capability-types";
@@ -15,15 +16,22 @@ export type PolicyRunKind = "chat" | "review";
 export interface PolicyEngineOptions {
     platform?: AgentRuntimePlatform;
     /**
-     * Write Action Framework v1 parameters (Step 0 type skeleton).
+     * Write Action Framework v1 parameters (see framework SDD §4).
      *
-     * When omitted (legacy chat runtime), PolicyEngine behavior is 100% unchanged:
-     * kind="action" rejected, permission must be "read-only"|"network-read",
-     * requiresConfirmation must be false, failureBehavior must be "recoverable".
+     * When omitted (legacy chat runtime caller, e.g. pa-agent-runtime.ts:488),
+     * PolicyEngine behavior is 100% unchanged from PA v1:
+     * - kind="action" rejected (defaults: runKind="chat", allowWrite=false)
+     * - non-action permission must be "read-only" | "network-read"
+     * - non-action requiresConfirmation must be false
+     * - failureBehavior must be "recoverable"
      *
-     * When runKind="review" AND allowWrite=true, kind="action" capabilities whose permission
-     * is in `allowedActionPermissions` are permitted. The behavior matrix is implemented in
-     * Track A · A1 (see docs/sdd-rollout-plan.md §3.2 and framework SDD §4).
+     * When `runKind="review"` AND `allowWrite=true` (review runtime / future Operations
+     * Agent mode), kind="action" capabilities whose permission is listed in
+     * `allowedActionPermissions` are permitted. Any other combination
+     * (runKind="chat" with any allowWrite, or runKind="review" with allowWrite=false)
+     * keeps the strict chat-runtime behavior.
+     *
+     * Non-action capabilities retain the v1 chat constraints regardless of runKind/allowWrite.
      */
     runKind?: PolicyRunKind;
     allowWrite?: boolean;
@@ -34,13 +42,13 @@ export class PolicyEngine {
     private readonly platform: AgentRuntimePlatform;
     private readonly runKind: PolicyRunKind;
     private readonly allowWrite: boolean;
-    private readonly allowedActionPermissions: readonly AgentPermissionFuture[];
+    private readonly allowedActionPermissions: ReadonlySet<AgentPermission>;
 
     constructor(options: PolicyEngineOptions = {}) {
         this.platform = options.platform ?? "desktop";
         this.runKind = options.runKind ?? "chat";
         this.allowWrite = options.allowWrite ?? false;
-        this.allowedActionPermissions = options.allowedActionPermissions ?? [];
+        this.allowedActionPermissions = new Set<AgentPermission>(options.allowedActionPermissions ?? []);
     }
 
     canExport(capability: AgentCapability): CapabilityPolicyDecision {
@@ -57,16 +65,37 @@ export class PolicyEngine {
 
     private evaluate(capability: AgentCapability): CapabilityPolicyDecision {
         if (capability.kind === "action") {
-            return { allowed: false, reason: "action capabilities are reserved for future action mode" };
-        }
-        if (capability.permission !== "read-only" && capability.permission !== "network-read") {
-            return { allowed: false, reason: `permission ${capability.permission} is not allowed in PA Agent v1` };
-        }
-        if (capability.requiresConfirmation !== false) {
-            return { allowed: false, reason: "v1 capabilities must not require confirmation" };
+            if (this.runKind !== "review" || !this.allowWrite) {
+                return {
+                    allowed: false,
+                    reason: `action capabilities require runKind="review" AND allowWrite=true`,
+                };
+            }
+            if (!this.allowedActionPermissions.has(capability.permission)) {
+                return {
+                    allowed: false,
+                    reason: `action permission "${capability.permission}" not in allowlist`,
+                };
+            }
+            // Action capabilities are required to have requiresConfirmation=true at the
+            // type layer (see write-action-framework/types.ts WriteActionCapability).
+            // PolicyEngine does not re-validate that flag here; framework gates enforce it
+            // at execution time via the Preview-Confirmation Lifecycle.
+        } else {
+            // Non-action capability: retain PA v1 chat constraints (read-only/network-read,
+            // no confirmation, recoverable). These limits hold regardless of allowWrite.
+            if (capability.permission !== "read-only" && capability.permission !== "network-read") {
+                return {
+                    allowed: false,
+                    reason: `permission ${capability.permission} is not allowed for non-action capabilities`,
+                };
+            }
+            if (capability.requiresConfirmation !== false) {
+                return { allowed: false, reason: "non-action capabilities must not require confirmation" };
+            }
         }
         if (capability.failureBehavior !== "recoverable") {
-            return { allowed: false, reason: "v1 capabilities must be recoverable" };
+            return { allowed: false, reason: "capabilities must be recoverable" };
         }
         if (!isPlatformSupported(capability.platform, this.platform)) {
             return { allowed: false, reason: `capability is not supported on ${this.platform}` };

--- a/src/ai-services/write-action-framework/debug-observer.spec.ts
+++ b/src/ai-services/write-action-framework/debug-observer.spec.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it, jest } from "@jest/globals";
+
+import {
+    combineDebugObservers,
+    ConsoleDebugObserver,
+    NOOP_DEBUG_OBSERVER,
+    NoopDebugObserver,
+} from "./debug-observer";
+import type { DebugEvent, DebugEventType, DebugObserver } from "./types";
+
+/**
+ * Canonical list of every DebugEventType (framework SDD §2.4). Asserted in the
+ * `ALL_DEBUG_EVENT_TYPES` test below to catch any future drift between
+ * `types.ts` and the runtime emitters.
+ */
+const ALL_DEBUG_EVENT_TYPES: DebugEventType[] = [
+    "gate.target-confinement.ok",
+    "gate.target-confinement.reject",
+    "gate.preview.shown",
+    "gate.confirmation.received",
+    "gate.stale-reread.ok",
+    "gate.stale-reread.drift",
+    "execute.ok",
+    "execute.fail",
+    "rollback.ok",
+    "rollback.fail",
+];
+
+function buildEvent(type: DebugEventType, extra: Partial<DebugEvent> = {}): DebugEvent {
+    return {
+        type,
+        capabilityId: "pagelet.write_review_output",
+        runId: "run-1",
+        turnId: "turn-1",
+        ...extra,
+    };
+}
+
+describe("NoopDebugObserver", () => {
+    it("is a constant-time no-op for every event type", () => {
+        const obs = new NoopDebugObserver();
+        for (const type of ALL_DEBUG_EVENT_TYPES) {
+            expect(() => obs.emit(buildEvent(type))).not.toThrow();
+        }
+    });
+
+    it("NOOP_DEBUG_OBSERVER singleton emits without side effects", () => {
+        expect(typeof NOOP_DEBUG_OBSERVER.emit).toBe("function");
+        // Spy console.debug to verify NoopDebugObserver does NOT touch it.
+        // eslint-disable-next-line no-console
+        const spy = jest.spyOn(console, "debug").mockImplementation(() => undefined);
+        NOOP_DEBUG_OBSERVER.emit(buildEvent("execute.ok"));
+        expect(spy).not.toHaveBeenCalled();
+        spy.mockRestore();
+    });
+});
+
+describe("ConsoleDebugObserver (framework SDD §2.4)", () => {
+    it("emits each of the 10 DebugEventTypes via the injected logger", () => {
+        const logger = jest.fn();
+        const obs = new ConsoleDebugObserver(logger);
+        const seen = new Set<DebugEventType>();
+        for (const type of ALL_DEBUG_EVENT_TYPES) {
+            obs.emit(buildEvent(type));
+            seen.add(type);
+        }
+        expect(seen.size).toBe(10);
+        expect(logger).toHaveBeenCalledTimes(10);
+    });
+
+    it("uses the [write-action-framework] prefix and includes the type + capabilityId", () => {
+        const logger = jest.fn();
+        const obs = new ConsoleDebugObserver(logger);
+        obs.emit(buildEvent("gate.target-confinement.reject", {
+            errorCategory: "rejected_at_confinement",
+        }));
+        const firstCall = logger.mock.calls[0] as unknown[];
+        expect(firstCall[0]).toBe("[write-action-framework] gate.target-confinement.reject pagelet.write_review_output");
+        expect(firstCall[1]).toMatchObject({
+            type: "gate.target-confinement.reject",
+            capabilityId: "pagelet.write_review_output",
+            errorCategory: "rejected_at_confinement",
+        });
+    });
+
+    it("accepts a custom prefix for downstream filtering", () => {
+        const logger = jest.fn();
+        const obs = new ConsoleDebugObserver(logger, "[pagelet-runtime]");
+        obs.emit(buildEvent("execute.ok"));
+        const firstCall = logger.mock.calls[0] as unknown[];
+        expect(firstCall[0]).toMatch(/^\[pagelet-runtime\]/);
+    });
+
+    it("defaults to console.debug when no logger supplied (smoke)", () => {
+        // eslint-disable-next-line no-console
+        const spy = jest.spyOn(console, "debug").mockImplementation(() => undefined);
+        const obs = new ConsoleDebugObserver();
+        obs.emit(buildEvent("rollback.ok"));
+        expect(spy).toHaveBeenCalledTimes(1);
+        spy.mockRestore();
+    });
+});
+
+describe("combineDebugObservers", () => {
+    it("returns NOOP when given zero observers", () => {
+        expect(combineDebugObservers()).toBe(NOOP_DEBUG_OBSERVER);
+    });
+
+    it("returns the single observer unchanged when given one", () => {
+        const obs = new NoopDebugObserver();
+        expect(combineDebugObservers(obs)).toBe(obs);
+    });
+
+    it("fan-outs to every observer", () => {
+        const a = jest.fn();
+        const b = jest.fn();
+        const observerA: DebugObserver = { emit: a };
+        const observerB: DebugObserver = { emit: b };
+        const combined = combineDebugObservers(observerA, observerB);
+        const evt = buildEvent("execute.ok");
+        combined.emit(evt);
+        expect(a).toHaveBeenCalledWith(evt);
+        expect(b).toHaveBeenCalledWith(evt);
+    });
+
+    it("isolates a throwing observer from the rest", () => {
+        const good = jest.fn();
+        const bad: DebugObserver = {
+            emit: () => {
+                throw new Error("observer crashed");
+            },
+        };
+        const goodObserver: DebugObserver = { emit: good };
+        const combined = combineDebugObservers(bad, goodObserver);
+        const evt = buildEvent("execute.fail");
+        expect(() => combined.emit(evt)).not.toThrow();
+        expect(good).toHaveBeenCalledWith(evt);
+    });
+});

--- a/src/ai-services/write-action-framework/debug-observer.ts
+++ b/src/ai-services/write-action-framework/debug-observer.ts
@@ -1,0 +1,69 @@
+/**
+ * Debug Observability Hook — framework SDD §2.4.
+ *
+ * **Not** a production audit store. v1 only emits structured events to a configured
+ * DebugObserver for developer triage; nothing is persisted to disk, no retention
+ * policy, no opt-in tier. Two built-in implementations:
+ *
+ *   - {@link NoopDebugObserver}  — production default; zero-overhead no-op.
+ *   - {@link ConsoleDebugObserver} — development default; routes to console.debug
+ *     with a stable `[write-action-framework]` prefix for grep-ability.
+ *
+ * Future Operations Agent mode (v2+) may inject a `PersistentAuditObserver`
+ * implementing the same `DebugObserver` interface without changing framework
+ * internals (framework SDD §10 upgrade trigger).
+ */
+
+import type { DebugEvent, DebugObserver } from "./types";
+
+/** Production default. Discards every event. Constant-time, allocation-free. */
+export class NoopDebugObserver implements DebugObserver {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    emit(_event: DebugEvent): void {
+        /* intentionally empty */
+    }
+}
+
+/** Shared singleton instance for the common case (avoid per-runtime allocation). */
+export const NOOP_DEBUG_OBSERVER: DebugObserver = new NoopDebugObserver();
+
+/**
+ * Routes events to `console.debug` (or a caller-supplied logger for test
+ * isolation). Each event is logged as a single call so devtools can collapse
+ * by group: `[write-action-framework] {type} {capabilityId}` + raw event object.
+ */
+export class ConsoleDebugObserver implements DebugObserver {
+    constructor(
+        private readonly logger: (...args: unknown[]) => void = (...args) =>
+            // eslint-disable-next-line no-console
+            console.debug(...args),
+        private readonly prefix: string = "[write-action-framework]",
+    ) {}
+
+    emit(event: DebugEvent): void {
+        // Single-call format keeps grep/devtools collapsing predictable.
+        this.logger(`${this.prefix} ${event.type} ${event.capabilityId}`, event);
+    }
+}
+
+/**
+ * Convenience: wrap an observer to fan out to multiple sinks (e.g., console +
+ * future persistent audit). Returned observer is itself a DebugObserver so it
+ * composes recursively.
+ */
+export function combineDebugObservers(...observers: DebugObserver[]): DebugObserver {
+    if (observers.length === 0) return NOOP_DEBUG_OBSERVER;
+    if (observers.length === 1) return observers[0];
+    return {
+        emit(event: DebugEvent): void {
+            for (const obs of observers) {
+                try {
+                    obs.emit(event);
+                } catch {
+                    // One bad observer must not break the rest. Framework debug emit
+                    // is best-effort and never throws back into the action lifecycle.
+                }
+            }
+        },
+    };
+}

--- a/src/ai-services/write-action-framework/index.ts
+++ b/src/ai-services/write-action-framework/index.ts
@@ -1,11 +1,66 @@
 export type {
+    ConfinementConfig,
     ConfirmationOutcome,
     DebugErrorCategory,
     DebugEvent,
     DebugEventType,
     DebugObserver,
     PreviewSpec,
+    TargetSnapshot,
     WriteActionCapability,
     WriteActionExecuteHooks,
     WriteActionFamily,
 } from "./types";
+
+export {
+    DEFAULT_MAX_PATH_LENGTH,
+    validateTargetConfinement,
+    validateTargetConfinementSync,
+} from "./target-confinement";
+export type {
+    ConfinementFsProbe,
+    ConfinementRejectReason,
+    ConfinementResult,
+} from "./target-confinement";
+
+export {
+    combineDebugObservers,
+    ConsoleDebugObserver,
+    NOOP_DEBUG_OBSERVER,
+    NoopDebugObserver,
+} from "./debug-observer";
+
+export {
+    checkStaleReread,
+    takeSnapshot,
+} from "./stale-reread";
+export type {
+    StaleDriftDetail,
+    StaleReadProbe,
+    StaleReadResult,
+} from "./stale-reread";
+
+export {
+    createDefaultObsidianPreviewRenderer,
+    createMutexPreviewRenderer,
+    ObsidianPreviewRenderer,
+    WriteActionPreviewModal,
+} from "./preview-modal";
+export type {
+    PreviewRenderer,
+    PreviewShowOptions,
+    PreviewShowResult,
+} from "./preview-modal";
+
+export {
+    createActionExecutor,
+    createSelfWriteRegistry,
+    SELF_WRITE_WINDOW_MS,
+} from "./runtime-integration";
+export type {
+    ActionExecutor,
+    ActionExecutorOptions,
+    FsProbe,
+    SelfWriteRegistry,
+    SelfWriteRegistryOptions,
+} from "./runtime-integration";

--- a/src/ai-services/write-action-framework/index.ts
+++ b/src/ai-services/write-action-framework/index.ts
@@ -61,6 +61,7 @@ export type {
     ActionExecutor,
     ActionExecutorOptions,
     FsProbe,
+    FsRemoveProbe,
     SelfWriteRegistry,
     SelfWriteRegistryOptions,
 } from "./runtime-integration";

--- a/src/ai-services/write-action-framework/preview-modal.spec.ts
+++ b/src/ai-services/write-action-framework/preview-modal.spec.ts
@@ -30,9 +30,10 @@ function createEl(): MockEl {
     el.setText = jest.fn((text: unknown) => {
         el.text = typeof text === "string" ? text : String(text ?? "");
     });
-    el.createEl = jest.fn((_tag: unknown, options?: unknown) => {
+    el.createEl = jest.fn((tag: unknown, options?: unknown) => {
         const opts = (options ?? {}) as { text?: string; cls?: string };
         const child = createEl();
+        child.tag = typeof tag === "string" ? tag : "";
         if (opts.text) child.text = opts.text;
         if (opts.cls) child.cls = opts.cls;
         el.children.push(child);
@@ -49,10 +50,29 @@ function createEl(): MockEl {
     return el;
 }
 
+function flattenSubtree(root: MockEl): MockEl[] {
+    const out: MockEl[] = [];
+    const stack: MockEl[] = [root];
+    while (stack.length > 0) {
+        const node = stack.pop();
+        if (!node) continue;
+        out.push(node);
+        for (const child of (node.children ?? []) as MockEl[]) {
+            stack.push(child);
+        }
+    }
+    return out;
+}
+
+const markdownRenderCalls: Array<{ markdown: string; sourcePath: string }> = [];
+
 jest.mock("obsidian", () => ({
     Modal: class {
+        app: unknown;
         contentEl: MockEl = createEl();
-        constructor(_app: unknown) {}
+        constructor(app: unknown) {
+            this.app = app;
+        }
         open(): void {
             (this as unknown as { onOpen: () => void }).onOpen();
         }
@@ -92,6 +112,18 @@ jest.mock("obsidian", () => ({
             return this;
         }
     },
+    Component: class {
+        load(): void {}
+        unload(): void {}
+    },
+    MarkdownRenderer: {
+        render: jest.fn(
+            (_app: unknown, markdown: string, el: MockEl, sourcePath: string) => {
+                markdownRenderCalls.push({ markdown, sourcePath });
+                el.setText?.(markdown);
+            },
+        ),
+    },
 }));
 
 // IMPORTANT: imports MUST come after jest.mock so the mock is wired before the
@@ -106,54 +138,94 @@ import {
 // eslint-disable-next-line import/first
 import type { ConfirmationOutcome, PreviewSpec } from "./types";
 
-function buildSpec(): PreviewSpec {
+function buildSpec(overrides: Partial<PreviewSpec> = {}): PreviewSpec {
     return {
-        target: { path: ".pagelet/2026-06-02-meeting.md", category: "pagelet-review-note" },
-        contentMarkdown: "# Heading\n\n- bullet\n- bullet",
-        impact: "Creates 1 new file in .pagelet/",
-        risk: "No external state.",
-        action: "Create file .pagelet/2026-06-02-meeting.md",
+        operationType: "create-file",
+        actionFamily: "pagelet-review-note",
+        capabilityId: "pagelet.write_review_output",
+        target: {
+            kind: "vault-path",
+            displayPath: ".pagelet/2026-06-02-meeting.md",
+            folder: ".pagelet/",
+            filename: "2026-06-02-meeting.md",
+        },
+        contentPreview: {
+            format: "markdown",
+            body: "# Heading\n\n- bullet\n- bullet",
+            byteSize: 28,
+        },
+        impact: {
+            usesAiProvider: false,
+            usesAiCredits: false,
+            affectsExternalState: false,
+        },
+        riskNotes: [],
+        confirmCopy: { confirmLabel: "Adopt", cancelLabel: "Cancel" },
+        ...overrides,
     };
 }
 
 beforeEach(() => {
     mockSettingGroups.length = 0;
+    markdownRenderCalls.length = 0;
 });
 
-describe("WriteActionPreviewModal (5-section rendering)", () => {
-    it("renders all 5 sections + header on open", () => {
+describe("WriteActionPreviewModal (PreviewSpec section rendering)", () => {
+    it("renders Target/Preview/Impact/Risk sections + header on open", () => {
         const outcomes: ConfirmationOutcome[] = [];
         const modal = new WriteActionPreviewModal({} as never, buildSpec(), (o) => outcomes.push(o));
         modal.onOpen();
         // `contentEl` is typed as HTMLElement by Obsidian's Modal but is actually
         // our MockEl at runtime (per jest.mock above) — cast for inspection.
         const contentEl = (modal as unknown as { contentEl: MockEl }).contentEl;
-        // Header h2 + 5 sections (target, impact, risk, action, content).
-        const titles = (contentEl.children as MockEl[])
-            .flatMap((c: MockEl) => c.children as MockEl[])
-            .filter((c: MockEl) => typeof c.cls === "string" && c.cls.includes("pa-write-action-modal__section-title"))
+        const titles = flattenSubtree(contentEl)
+            .filter((c: MockEl) =>
+                typeof c.cls === "string"
+                && c.cls.includes("pa-write-action-modal__section-title"),
+            )
             .map((c: MockEl) => c.text);
         expect(titles).toEqual(
-            expect.arrayContaining(["Target", "Impact", "Risk", "Action", "Preview"]),
+            expect.arrayContaining(["Target", "Preview", "Impact", "Risk"]),
         );
-        // Content body received the markdown text via setText().
-        const contentBody = (contentEl.children as MockEl[])
-            .flatMap((c: MockEl) => c.children as MockEl[])
-            .find((c: MockEl) =>
-                typeof c.cls === "string"
-                && c.cls.includes("pa-write-action-modal__section-body")
-                && typeof c.text === "string"
-                && c.text.includes("# Heading"),
-            );
-        expect(contentBody).toBeDefined();
+        // Header h2 includes the actionFamily · capabilityId banner.
+        const header = flattenSubtree(contentEl).find((c: MockEl) => c.tag === "h2");
+        expect(header?.text).toContain("pagelet-review-note");
+        expect(header?.text).toContain("pagelet.write_review_output");
     });
 
-    it("captures confirmed outcome via primary CTA button", () => {
+    it("uses MarkdownRenderer.render when contentPreview.format=markdown", () => {
         const outcomes: ConfirmationOutcome[] = [];
         const modal = new WriteActionPreviewModal({} as never, buildSpec(), (o) => outcomes.push(o));
         modal.onOpen();
+        expect(markdownRenderCalls).toHaveLength(1);
+        expect(markdownRenderCalls[0].markdown).toContain("# Heading");
+        expect(markdownRenderCalls[0].sourcePath).toBe(".pagelet/2026-06-02-meeting.md");
+    });
+
+    it("renders <pre> fallback when contentPreview.format=plain-text", () => {
+        const outcomes: ConfirmationOutcome[] = [];
+        const spec = buildSpec({
+            contentPreview: { format: "plain-text", body: "Plain text body", byteSize: 15 },
+        });
+        const modal = new WriteActionPreviewModal({} as never, spec, (o) => outcomes.push(o));
+        modal.onOpen();
+        expect(markdownRenderCalls).toHaveLength(0);
+        const contentEl = (modal as unknown as { contentEl: MockEl }).contentEl;
+        const pre = flattenSubtree(contentEl).find(
+            (c: MockEl) => c.tag === "pre" && typeof c.text === "string" && c.text.includes("Plain text body"),
+        );
+        expect(pre).toBeDefined();
+    });
+
+    it("uses confirmCopy.confirmLabel/cancelLabel for buttons", () => {
+        const outcomes: ConfirmationOutcome[] = [];
+        const spec = buildSpec({
+            confirmCopy: { confirmLabel: "采纳", cancelLabel: "取消" },
+        });
+        const modal = new WriteActionPreviewModal({} as never, spec, (o) => outcomes.push(o));
+        modal.onOpen();
         const buttons = mockSettingGroups.flat();
-        expect(buttons.map((b) => b.text)).toEqual(["Confirm", "Cancel"]);
+        expect(buttons.map((b) => b.text)).toEqual(["采纳", "取消"]);
         expect(buttons[0].cta).toBe(true);
         buttons[0].click?.();
         expect(outcomes).toEqual(["confirmed"]);
@@ -168,12 +240,12 @@ describe("WriteActionPreviewModal (5-section rendering)", () => {
         expect(outcomes).toEqual(["cancelled"]);
     });
 
-    it("captures closed outcome when modal closed without resolving", () => {
+    it("maps onClose (✕ / click-outside / ESC) to cancelled per SDD §2.1", () => {
         const outcomes: ConfirmationOutcome[] = [];
         const modal = new WriteActionPreviewModal({} as never, buildSpec(), (o) => outcomes.push(o));
         modal.onOpen();
         modal.onClose();
-        expect(outcomes).toEqual(["closed"]);
+        expect(outcomes).toEqual(["cancelled"]);
     });
 
     it("captures aborted outcome via forceResolve (external signal)", () => {
@@ -279,9 +351,9 @@ describe("createMutexPreviewRenderer (serial mutex)", () => {
         await Promise.resolve();
         await Promise.resolve();
         expect(ctrl.pending.length).toBe(1);
-        ctrl.pending.shift()?.("closed");
+        ctrl.pending.shift()?.("aborted");
         const r3 = await p3;
-        expect(r3).toEqual({ outcome: "closed" });
+        expect(r3).toEqual({ outcome: "aborted" });
     });
 
     it("returns aborted without invoking inner renderer when signal aborts while queued", async () => {

--- a/src/ai-services/write-action-framework/preview-modal.spec.ts
+++ b/src/ai-services/write-action-framework/preview-modal.spec.ts
@@ -1,0 +1,324 @@
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+
+/**
+ * Per-suite obsidian mock: provides a richer Modal + Setting than the project's
+ * shared `__mocks__/obsidian.ts`, so we can assert section rendering and button
+ * wiring without booting a real Obsidian app. Pattern lifted from
+ * `__tests__/memory-manager.test.ts`.
+ */
+type SettingButton = { text?: string; cta?: boolean; click?: () => void };
+const mockSettingGroups: SettingButton[][] = [];
+
+// Use `any` to dodge jest.Mock<UnknownFunction> strict-typing for arbitrary
+// signatures — same pattern as __tests__/memory-manager.test.ts.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type MockEl = any;
+
+function createEl(): MockEl {
+    const el = {
+        children: [] as MockEl[],
+        text: "",
+        cls: "",
+    } as MockEl;
+    el.addClass = jest.fn((cls?: unknown) => {
+        if (typeof cls === "string") el.cls = el.cls ? `${el.cls} ${cls}` : cls;
+    });
+    el.empty = jest.fn(() => {
+        el.children.length = 0;
+        el.text = "";
+    });
+    el.setText = jest.fn((text: unknown) => {
+        el.text = typeof text === "string" ? text : String(text ?? "");
+    });
+    el.createEl = jest.fn((_tag: unknown, options?: unknown) => {
+        const opts = (options ?? {}) as { text?: string; cls?: string };
+        const child = createEl();
+        if (opts.text) child.text = opts.text;
+        if (opts.cls) child.cls = opts.cls;
+        el.children.push(child);
+        return child;
+    });
+    el.createDiv = jest.fn((options?: unknown) => {
+        const opts = (options ?? {}) as { text?: string; cls?: string };
+        const child = createEl();
+        if (opts.text) child.text = opts.text;
+        if (opts.cls) child.cls = opts.cls;
+        el.children.push(child);
+        return child;
+    });
+    return el;
+}
+
+jest.mock("obsidian", () => ({
+    Modal: class {
+        contentEl: MockEl = createEl();
+        constructor(_app: unknown) {}
+        open(): void {
+            (this as unknown as { onOpen: () => void }).onOpen();
+        }
+        close(): void {
+            (this as unknown as { onClose: () => void }).onClose();
+        }
+        onOpen(): void {}
+        onClose(): void {}
+    },
+    Setting: class {
+        private readonly buttons: SettingButton[] = [];
+        constructor(_container: unknown) {
+            mockSettingGroups.push(this.buttons);
+        }
+        addButton(cb: (b: {
+            setCta: () => unknown;
+            setButtonText: (t: string) => unknown;
+            onClick: (fn: () => void) => unknown;
+        }) => void): this {
+            const record: SettingButton = {};
+            this.buttons.push(record);
+            const btn = {
+                setCta: () => {
+                    record.cta = true;
+                    return btn;
+                },
+                setButtonText: (text: string) => {
+                    record.text = text;
+                    return btn;
+                },
+                onClick: (fn: () => void) => {
+                    record.click = fn;
+                    return btn;
+                },
+            };
+            cb(btn);
+            return this;
+        }
+    },
+}));
+
+// IMPORTANT: imports MUST come after jest.mock so the mock is wired before the
+// preview-modal module pulls in obsidian.
+// eslint-disable-next-line import/first
+import {
+    createMutexPreviewRenderer,
+    ObsidianPreviewRenderer,
+    WriteActionPreviewModal,
+    type PreviewRenderer,
+} from "./preview-modal";
+// eslint-disable-next-line import/first
+import type { ConfirmationOutcome, PreviewSpec } from "./types";
+
+function buildSpec(): PreviewSpec {
+    return {
+        target: { path: ".pagelet/2026-06-02-meeting.md", category: "pagelet-review-note" },
+        contentMarkdown: "# Heading\n\n- bullet\n- bullet",
+        impact: "Creates 1 new file in .pagelet/",
+        risk: "No external state.",
+        action: "Create file .pagelet/2026-06-02-meeting.md",
+    };
+}
+
+beforeEach(() => {
+    mockSettingGroups.length = 0;
+});
+
+describe("WriteActionPreviewModal (5-section rendering)", () => {
+    it("renders all 5 sections + header on open", () => {
+        const outcomes: ConfirmationOutcome[] = [];
+        const modal = new WriteActionPreviewModal({} as never, buildSpec(), (o) => outcomes.push(o));
+        modal.onOpen();
+        // `contentEl` is typed as HTMLElement by Obsidian's Modal but is actually
+        // our MockEl at runtime (per jest.mock above) — cast for inspection.
+        const contentEl = (modal as unknown as { contentEl: MockEl }).contentEl;
+        // Header h2 + 5 sections (target, impact, risk, action, content).
+        const titles = (contentEl.children as MockEl[])
+            .flatMap((c: MockEl) => c.children as MockEl[])
+            .filter((c: MockEl) => typeof c.cls === "string" && c.cls.includes("pa-write-action-modal__section-title"))
+            .map((c: MockEl) => c.text);
+        expect(titles).toEqual(
+            expect.arrayContaining(["Target", "Impact", "Risk", "Action", "Preview"]),
+        );
+        // Content body received the markdown text via setText().
+        const contentBody = (contentEl.children as MockEl[])
+            .flatMap((c: MockEl) => c.children as MockEl[])
+            .find((c: MockEl) =>
+                typeof c.cls === "string"
+                && c.cls.includes("pa-write-action-modal__section-body")
+                && typeof c.text === "string"
+                && c.text.includes("# Heading"),
+            );
+        expect(contentBody).toBeDefined();
+    });
+
+    it("captures confirmed outcome via primary CTA button", () => {
+        const outcomes: ConfirmationOutcome[] = [];
+        const modal = new WriteActionPreviewModal({} as never, buildSpec(), (o) => outcomes.push(o));
+        modal.onOpen();
+        const buttons = mockSettingGroups.flat();
+        expect(buttons.map((b) => b.text)).toEqual(["Confirm", "Cancel"]);
+        expect(buttons[0].cta).toBe(true);
+        buttons[0].click?.();
+        expect(outcomes).toEqual(["confirmed"]);
+    });
+
+    it("captures cancelled outcome via secondary button", () => {
+        const outcomes: ConfirmationOutcome[] = [];
+        const modal = new WriteActionPreviewModal({} as never, buildSpec(), (o) => outcomes.push(o));
+        modal.onOpen();
+        const buttons = mockSettingGroups.flat();
+        buttons[1].click?.();
+        expect(outcomes).toEqual(["cancelled"]);
+    });
+
+    it("captures closed outcome when modal closed without resolving", () => {
+        const outcomes: ConfirmationOutcome[] = [];
+        const modal = new WriteActionPreviewModal({} as never, buildSpec(), (o) => outcomes.push(o));
+        modal.onOpen();
+        modal.onClose();
+        expect(outcomes).toEqual(["closed"]);
+    });
+
+    it("captures aborted outcome via forceResolve (external signal)", () => {
+        const outcomes: ConfirmationOutcome[] = [];
+        const modal = new WriteActionPreviewModal({} as never, buildSpec(), (o) => outcomes.push(o));
+        modal.onOpen();
+        modal.forceResolve("aborted");
+        expect(outcomes).toEqual(["aborted"]);
+    });
+
+    it("does not double-resolve when onClose runs after a button click", () => {
+        const outcomes: ConfirmationOutcome[] = [];
+        const modal = new WriteActionPreviewModal({} as never, buildSpec(), (o) => outcomes.push(o));
+        modal.onOpen();
+        const buttons = mockSettingGroups.flat();
+        buttons[0].click?.(); // settles to "confirmed", which calls close() → onClose()
+        modal.onClose(); // simulate a late onClose
+        expect(outcomes).toEqual(["confirmed"]);
+    });
+});
+
+describe("ObsidianPreviewRenderer (Obsidian-backed renderer)", () => {
+    it("resolves with the outcome reported by the underlying modal", async () => {
+        const renderer = new ObsidianPreviewRenderer({} as never);
+        const showPromise = renderer.show(buildSpec());
+        // After show(), buttons should be available via the latest mockSettingGroups entry.
+        // The modal's open() ran inside the Promise constructor, so just click the CTA.
+        const buttons = mockSettingGroups.flat();
+        buttons[0].click?.();
+        await expect(showPromise).resolves.toEqual({ outcome: "confirmed" });
+    });
+
+    it("returns aborted immediately if signal already aborted at show()", async () => {
+        const renderer = new ObsidianPreviewRenderer({} as never);
+        const controller = new AbortController();
+        controller.abort();
+        await expect(renderer.show(buildSpec(), { signal: controller.signal })).resolves.toEqual({
+            outcome: "aborted",
+        });
+    });
+
+    it("forces aborted when signal fires while modal is open", async () => {
+        const renderer = new ObsidianPreviewRenderer({} as never);
+        const controller = new AbortController();
+        const showPromise = renderer.show(buildSpec(), { signal: controller.signal });
+        controller.abort();
+        await expect(showPromise).resolves.toEqual({ outcome: "aborted" });
+    });
+});
+
+describe("createMutexPreviewRenderer (serial mutex)", () => {
+    /** A renderer that lets the test resolve each show() call explicitly. */
+    function makeControllableRenderer(): {
+        renderer: PreviewRenderer;
+        inFlight: number;
+        pending: Array<(o: ConfirmationOutcome) => void>;
+    } {
+        const state = {
+            renderer: null as unknown as PreviewRenderer,
+            inFlight: 0,
+            pending: [] as Array<(o: ConfirmationOutcome) => void>,
+        };
+        state.renderer = {
+            show: () => {
+                state.inFlight += 1;
+                if (state.inFlight > 1) {
+                    throw new Error("mutex breach: two concurrent show() calls");
+                }
+                return new Promise((resolve) => {
+                    state.pending.push((outcome) => {
+                        state.inFlight -= 1;
+                        resolve({ outcome });
+                    });
+                });
+            },
+        };
+        return state;
+    }
+
+    it("serializes concurrent show() calls FIFO", async () => {
+        const ctrl = makeControllableRenderer();
+        const mutexed = createMutexPreviewRenderer(ctrl.renderer);
+        const p1 = mutexed.show(buildSpec());
+        const p2 = mutexed.show(buildSpec());
+        const p3 = mutexed.show(buildSpec());
+        // Only the first should be active.
+        await Promise.resolve();
+        await Promise.resolve();
+        expect(ctrl.pending.length).toBe(1);
+        ctrl.pending.shift()?.("confirmed");
+        const r1 = await p1;
+        expect(r1).toEqual({ outcome: "confirmed" });
+
+        // Second now starts.
+        await Promise.resolve();
+        await Promise.resolve();
+        expect(ctrl.pending.length).toBe(1);
+        ctrl.pending.shift()?.("cancelled");
+        const r2 = await p2;
+        expect(r2).toEqual({ outcome: "cancelled" });
+
+        // Third now starts.
+        await Promise.resolve();
+        await Promise.resolve();
+        expect(ctrl.pending.length).toBe(1);
+        ctrl.pending.shift()?.("closed");
+        const r3 = await p3;
+        expect(r3).toEqual({ outcome: "closed" });
+    });
+
+    it("returns aborted without invoking inner renderer when signal aborts while queued", async () => {
+        const ctrl = makeControllableRenderer();
+        const mutexed = createMutexPreviewRenderer(ctrl.renderer);
+        const controller = new AbortController();
+        const p1 = mutexed.show(buildSpec());
+        const p2 = mutexed.show(buildSpec(), { signal: controller.signal });
+
+        // Flush microtasks so p1's `await myTurn` resolves and inner.show() is
+        // actually invoked (registering a pending resolver). Without these
+        // awaits, the shift() below would no-op (pending is still empty).
+        await Promise.resolve();
+        await Promise.resolve();
+        expect(ctrl.pending.length).toBe(1);
+
+        // p2 is queued behind p1; abort the controller before p1 resolves.
+        controller.abort();
+        // p1 still pending → resolve it; p2 should then short-circuit to aborted.
+        ctrl.pending.shift()?.("confirmed");
+        await p1;
+        await expect(p2).resolves.toEqual({ outcome: "aborted" });
+        // Inner renderer must not have been called for p2.
+        expect(ctrl.pending.length).toBe(0);
+    });
+
+    it("recovers and continues serving subsequent calls when an inner show() throws", async () => {
+        const calls: number[] = [];
+        const inner: PreviewRenderer = {
+            show: jest.fn(async () => {
+                calls.push(calls.length);
+                if (calls.length === 1) throw new Error("boom");
+                return { outcome: "confirmed" as ConfirmationOutcome };
+            }) as PreviewRenderer["show"],
+        };
+        const mutexed = createMutexPreviewRenderer(inner);
+        await expect(mutexed.show(buildSpec())).rejects.toThrow("boom");
+        await expect(mutexed.show(buildSpec())).resolves.toEqual({ outcome: "confirmed" });
+    });
+});

--- a/src/ai-services/write-action-framework/preview-modal.ts
+++ b/src/ai-services/write-action-framework/preview-modal.ts
@@ -1,0 +1,227 @@
+/**
+ * Preview-Confirmation Lifecycle (Gate 2) — framework SDD §2.1.
+ *
+ * Generalizes the multi-section approval pattern from
+ * `src/memory-manager.ts:612-679` (MemoryApprovalModal) into a reusable modal
+ * that renders 5 PreviewSpec sections and captures a 4-valued
+ * {@link ConfirmationOutcome} from the user.
+ *
+ * Mutex policy (SDD §2.1: "**不允许并发 preview**"):
+ *   Concurrent show() calls are **serialized** (FIFO queue) — they wait their
+ *   turn instead of being rejected. Pagelet may legitimately schedule multiple
+ *   reviews; the user sees one modal at a time, in arrival order.
+ *
+ * Test seam:
+ *   {@link PreviewRenderer} interface is dependency-injectable. Tests pass an
+ *   in-memory `StubPreviewRenderer` (see preview-modal.spec.ts) to assert
+ *   outcome routing and mutex serialization without booting Obsidian.
+ *   Production wires {@link ObsidianPreviewRenderer} which extends Obsidian's
+ *   `Modal` class — only exercised in Obsidian integration tests.
+ *
+ * Outcome mapping (matches Step 0 ConfirmationOutcome enum):
+ *   - "confirmed": primary CTA clicked
+ *   - "cancelled": secondary button clicked
+ *   - "closed":    modal closed via X / ESC / click-outside (no explicit button)
+ *   - "aborted":   external AbortSignal fired (turn cancelled / plugin unload)
+ */
+
+import { Modal, Setting, type App } from "obsidian";
+
+import type { ConfirmationOutcome, PreviewSpec } from "./types";
+
+/** Captures the user's verdict plus diagnostics for debug emit. */
+export interface PreviewShowResult {
+    outcome: ConfirmationOutcome;
+    /** Section render errors (e.g., markdown render failed) — non-fatal. */
+    renderWarnings?: string[];
+}
+
+/** DI surface for Gate 2. Production = {@link ObsidianPreviewRenderer}; tests stub. */
+export interface PreviewRenderer {
+    show(spec: PreviewSpec, options?: PreviewShowOptions): Promise<PreviewShowResult>;
+}
+
+export interface PreviewShowOptions {
+    /** External cancellation source. When the signal aborts mid-await, outcome = "aborted". */
+    signal?: AbortSignal;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Mutex wrapper
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Wraps another PreviewRenderer to serialize concurrent show() calls FIFO.
+ * Each call awaits the prior call's completion before invoking the inner
+ * renderer. AbortSignal still works while queued: if the signal fires while
+ * a call is waiting in the queue, it skips the inner show() entirely.
+ */
+export function createMutexPreviewRenderer(inner: PreviewRenderer): PreviewRenderer {
+    let tail: Promise<unknown> = Promise.resolve();
+    return {
+        async show(spec: PreviewSpec, options?: PreviewShowOptions): Promise<PreviewShowResult> {
+            const myTurn = tail.then(() => undefined, () => undefined);
+            let release!: () => void;
+            tail = new Promise<void>((resolve) => {
+                release = resolve;
+            });
+            try {
+                await myTurn;
+                // Skip the inner renderer if we were aborted while queued.
+                if (options?.signal?.aborted) {
+                    return { outcome: "aborted" };
+                }
+                return await inner.show(spec, options);
+            } finally {
+                release();
+            }
+        },
+    };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Obsidian Modal implementation
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Per-spec lifecycle: build sections, capture outcome via promise resolution,
+ * unwire AbortSignal listener in finally. Generalizes MemoryApprovalModal.
+ */
+export class WriteActionPreviewModal extends Modal {
+    private settled = false;
+
+    constructor(
+        app: App,
+        private readonly spec: PreviewSpec,
+        private readonly onOutcome: (outcome: ConfirmationOutcome) => void,
+    ) {
+        super(app);
+    }
+
+    onOpen(): void {
+        const { contentEl } = this;
+        contentEl.empty();
+        contentEl.addClass("pa-write-action-modal");
+
+        // Header banner: action family + capability id from spec.target.category.
+        contentEl.createEl("h2", { text: `Write action: ${this.spec.target.category}` });
+
+        // Section 1: Target — high-visibility path display.
+        this.addSection("Target", this.spec.target.path, "pa-write-action-modal__target");
+        // Section 2: Impact — what side effects this incurs.
+        this.addSection("Impact", this.spec.impact, "pa-write-action-modal__impact");
+        // Section 3: Risk — caller-curated warning text.
+        this.addSection("Risk", this.spec.risk, "pa-write-action-modal__risk");
+        // Section 4: Action — what will happen on confirm.
+        this.addSection("Action", this.spec.action, "pa-write-action-modal__action");
+        // Section 5: Content preview — full markdown body (rendered as text in v1;
+        // future iteration may swap to MarkdownRenderer.render once a Component
+        // host is wired here).
+        const contentBlock = contentEl.createDiv({ cls: "pa-write-action-modal__content" });
+        contentBlock.createDiv({ cls: "pa-write-action-modal__section-title", text: "Preview" });
+        const body = contentBlock.createDiv({ cls: "pa-write-action-modal__section-body" });
+        body.setText(this.spec.contentMarkdown);
+
+        new Setting(contentEl)
+            .addButton((button) => {
+                button
+                    .setCta()
+                    .setButtonText("Confirm")
+                    .onClick(() => this.resolveWith("confirmed"));
+            })
+            .addButton((button) => {
+                button
+                    .setButtonText("Cancel")
+                    .onClick(() => this.resolveWith("cancelled"));
+            });
+    }
+
+    onClose(): void {
+        this.contentEl.empty();
+        // Modal closed without resolving — must report a non-confirmed outcome.
+        if (!this.settled) {
+            this.settled = true;
+            this.onOutcome("closed");
+        }
+    }
+
+    /**
+     * External resolution path (used by Obsidian renderer to fire "aborted"
+     * when an AbortSignal triggers mid-modal).
+     */
+    forceResolve(outcome: ConfirmationOutcome): void {
+        this.resolveWith(outcome);
+    }
+
+    private resolveWith(outcome: ConfirmationOutcome): void {
+        if (this.settled) return;
+        this.settled = true;
+        this.onOutcome(outcome);
+        this.close();
+    }
+
+    private addSection(title: string, body: string, extraClass?: string): void {
+        const section = this.contentEl.createDiv({
+            cls: extraClass
+                ? `pa-write-action-modal__section ${extraClass}`
+                : "pa-write-action-modal__section",
+        });
+        section.createDiv({ cls: "pa-write-action-modal__section-title", text: title });
+        section.createDiv({ cls: "pa-write-action-modal__section-body", text: body });
+    }
+}
+
+/**
+ * Default production renderer. Spawns a {@link WriteActionPreviewModal} per
+ * call. Tracks the live modal so an AbortSignal can dismiss it. Must be
+ * wrapped with {@link createMutexPreviewRenderer} to enforce serial display.
+ */
+export class ObsidianPreviewRenderer implements PreviewRenderer {
+    private liveModal: WriteActionPreviewModal | null = null;
+
+    constructor(private readonly app: App) {}
+
+    async show(spec: PreviewSpec, options?: PreviewShowOptions): Promise<PreviewShowResult> {
+        if (options?.signal?.aborted) {
+            return { outcome: "aborted" };
+        }
+        return new Promise<PreviewShowResult>((resolve) => {
+            const cleanup = (): void => {
+                this.liveModal = null;
+                if (options?.signal) {
+                    options.signal.removeEventListener("abort", onAbort);
+                }
+            };
+            const onAbort = (): void => {
+                this.liveModal?.forceResolve("aborted");
+            };
+            const modal = new WriteActionPreviewModal(this.app, spec, (outcome) => {
+                cleanup();
+                resolve({ outcome });
+            });
+            this.liveModal = modal;
+            if (options?.signal) {
+                options.signal.addEventListener("abort", onAbort, { once: true });
+            }
+            try {
+                modal.open();
+            } catch (error) {
+                cleanup();
+                resolve({
+                    outcome: "aborted",
+                    renderWarnings: [
+                        `modal mount failed: ${error instanceof Error ? error.message : String(error)}`,
+                    ],
+                });
+            }
+        });
+    }
+}
+
+/**
+ * Compose the Obsidian renderer with the mutex in one call. Use this in
+ * runtime wiring; tests can compose their own stacks.
+ */
+export function createDefaultObsidianPreviewRenderer(app: App): PreviewRenderer {
+    return createMutexPreviewRenderer(new ObsidianPreviewRenderer(app));
+}

--- a/src/ai-services/write-action-framework/preview-modal.ts
+++ b/src/ai-services/write-action-framework/preview-modal.ts
@@ -3,8 +3,8 @@
  *
  * Generalizes the multi-section approval pattern from
  * `src/memory-manager.ts:612-679` (MemoryApprovalModal) into a reusable modal
- * that renders 5 PreviewSpec sections and captures a 4-valued
- * {@link ConfirmationOutcome} from the user.
+ * that renders the {@link PreviewSpec} into 5 logical sections and captures a
+ * 4-valued {@link ConfirmationOutcome} from the user.
  *
  * Mutex policy (SDD §2.1: "**不允许并发 preview**"):
  *   Concurrent show() calls are **serialized** (FIFO queue) — they wait their
@@ -18,14 +18,14 @@
  *   Production wires {@link ObsidianPreviewRenderer} which extends Obsidian's
  *   `Modal` class — only exercised in Obsidian integration tests.
  *
- * Outcome mapping (matches Step 0 ConfirmationOutcome enum):
+ * Outcome mapping (matches SDD §2.1 table):
  *   - "confirmed": primary CTA clicked
- *   - "cancelled": secondary button clicked
- *   - "closed":    modal closed via X / ESC / click-outside (no explicit button)
+ *   - "cancelled": secondary button clicked / ESC / ✕ / click-outside
  *   - "aborted":   external AbortSignal fired (turn cancelled / plugin unload)
+ *   - "timeout":   reserved for Operations Agent mode; v1 never emits
  */
 
-import { Modal, Setting, type App } from "obsidian";
+import { Component, MarkdownRenderer, Modal, Setting, type App } from "obsidian";
 
 import type { ConfirmationOutcome, PreviewSpec } from "./types";
 
@@ -86,14 +86,22 @@ export function createMutexPreviewRenderer(inner: PreviewRenderer): PreviewRende
 /**
  * Per-spec lifecycle: build sections, capture outcome via promise resolution,
  * unwire AbortSignal listener in finally. Generalizes MemoryApprovalModal.
+ *
+ * Render policy:
+ *   - `contentPreview.format === "markdown"`: render through Obsidian's
+ *     `MarkdownRenderer.render`. On render failure we fall back to a `<pre>`
+ *     text block (SDD §2.1 failure behavior line 212) and surface a
+ *     renderWarning to the caller.
+ *   - `contentPreview.format === "plain-text"`: always `<pre>` text.
  */
 export class WriteActionPreviewModal extends Modal {
     private settled = false;
+    private readonly renderHost = new Component();
 
     constructor(
         app: App,
         private readonly spec: PreviewSpec,
-        private readonly onOutcome: (outcome: ConfirmationOutcome) => void,
+        private readonly onOutcome: (outcome: ConfirmationOutcome, warnings?: string[]) => void,
     ) {
         super(app);
     }
@@ -102,46 +110,100 @@ export class WriteActionPreviewModal extends Modal {
         const { contentEl } = this;
         contentEl.empty();
         contentEl.addClass("pa-write-action-modal");
+        const renderWarnings: string[] = [];
 
-        // Header banner: action family + capability id from spec.target.category.
-        contentEl.createEl("h2", { text: `Write action: ${this.spec.target.category}` });
+        // Header banner: actionFamily · capabilityId (SDD §2.1 section 1).
+        contentEl.createEl("h2", {
+            text: `${this.spec.actionFamily} · ${this.spec.capabilityId}`,
+        });
 
-        // Section 1: Target — high-visibility path display.
-        this.addSection("Target", this.spec.target.path, "pa-write-action-modal__target");
-        // Section 2: Impact — what side effects this incurs.
-        this.addSection("Impact", this.spec.impact, "pa-write-action-modal__impact");
-        // Section 3: Risk — caller-curated warning text.
-        this.addSection("Risk", this.spec.risk, "pa-write-action-modal__risk");
-        // Section 4: Action — what will happen on confirm.
-        this.addSection("Action", this.spec.action, "pa-write-action-modal__action");
-        // Section 5: Content preview — full markdown body (rendered as text in v1;
-        // future iteration may swap to MarkdownRenderer.render once a Component
-        // host is wired here).
-        const contentBlock = contentEl.createDiv({ cls: "pa-write-action-modal__content" });
-        contentBlock.createDiv({ cls: "pa-write-action-modal__section-title", text: "Preview" });
+        // Section 1: Target — operationType → displayPath.
+        this.addSection(
+            "Target",
+            `${this.spec.operationType} → ${this.spec.target.displayPath}`,
+            "pa-write-action-modal__target",
+        );
+
+        // Section 2: Content preview (markdown via MarkdownRenderer or
+        // plain-text via <pre> fallback).
+        const contentBlock = this.contentEl.createDiv({
+            cls: "pa-write-action-modal__section pa-write-action-modal__content",
+        });
+        contentBlock.createDiv({
+            cls: "pa-write-action-modal__section-title",
+            text: "Preview",
+        });
         const body = contentBlock.createDiv({ cls: "pa-write-action-modal__section-body" });
-        body.setText(this.spec.contentMarkdown);
+        if (this.spec.contentPreview.format === "markdown") {
+            try {
+                const renderResult = MarkdownRenderer.render(
+                    this.app,
+                    this.spec.contentPreview.body,
+                    body,
+                    this.spec.target.displayPath,
+                    this.renderHost,
+                ) as unknown;
+                if (renderResult instanceof Promise) {
+                    renderResult.catch((error: unknown) => {
+                        renderWarnings.push(
+                            `markdown render failed: ${error instanceof Error ? error.message : String(error)}`,
+                        );
+                        this.renderPlainTextFallback(body);
+                    });
+                }
+            } catch (error) {
+                renderWarnings.push(
+                    `markdown render failed: ${error instanceof Error ? error.message : String(error)}`,
+                );
+                this.renderPlainTextFallback(body);
+            }
+        } else {
+            this.renderPlainTextFallback(body);
+        }
 
-        new Setting(contentEl)
+        // Section 3: Impact — 3 booleans + byteSize.
+        const impactLines = [
+            `usesAiProvider: ${this.spec.impact.usesAiProvider}`,
+            `usesAiCredits: ${this.spec.impact.usesAiCredits}`,
+            `affectsExternalState: ${this.spec.impact.affectsExternalState}`,
+            `previewByteSize: ${this.spec.contentPreview.byteSize}`,
+        ];
+        this.addSection("Impact", impactLines.join("\n"), "pa-write-action-modal__impact");
+
+        // Section 4: Risk notes (callout per line). Render even when empty so
+        // the user sees an explicit "none" rather than wondering if the
+        // section was hidden.
+        const riskBody = this.spec.riskNotes.length > 0
+            ? this.spec.riskNotes.map((line) => `⚠️ ${line}`).join("\n")
+            : "none";
+        this.addSection("Risk", riskBody, "pa-write-action-modal__risk");
+
+        // Section 5: Action buttons (CTA + secondary). Labels come from the
+        // spec so capabilities can i18n.
+        new Setting(this.contentEl)
             .addButton((button) => {
                 button
                     .setCta()
-                    .setButtonText("Confirm")
-                    .onClick(() => this.resolveWith("confirmed"));
+                    .setButtonText(this.spec.confirmCopy.confirmLabel)
+                    .onClick(() => this.resolveWith("confirmed", renderWarnings));
             })
             .addButton((button) => {
                 button
-                    .setButtonText("Cancel")
-                    .onClick(() => this.resolveWith("cancelled"));
+                    .setButtonText(this.spec.confirmCopy.cancelLabel)
+                    .onClick(() => this.resolveWith("cancelled", renderWarnings));
             });
+
+        this.renderHost.load();
     }
 
     onClose(): void {
         this.contentEl.empty();
-        // Modal closed without resolving — must report a non-confirmed outcome.
+        this.renderHost.unload();
+        // Modal closed without resolving — SDD §2.1 maps ✕ / click-outside / ESC
+        // to "cancelled". v1 doesn't emit a distinct "closed" outcome.
         if (!this.settled) {
             this.settled = true;
-            this.onOutcome("closed");
+            this.onOutcome("cancelled");
         }
     }
 
@@ -153,11 +215,16 @@ export class WriteActionPreviewModal extends Modal {
         this.resolveWith(outcome);
     }
 
-    private resolveWith(outcome: ConfirmationOutcome): void {
+    private resolveWith(outcome: ConfirmationOutcome, warnings?: string[]): void {
         if (this.settled) return;
         this.settled = true;
-        this.onOutcome(outcome);
+        this.onOutcome(outcome, warnings);
         this.close();
+    }
+
+    private renderPlainTextFallback(body: HTMLElement): void {
+        const pre = body.createEl("pre", { cls: "pa-write-action-modal__plain-text" });
+        pre.setText(this.spec.contentPreview.body);
     }
 
     private addSection(title: string, body: string, extraClass?: string): void {
@@ -195,9 +262,11 @@ export class ObsidianPreviewRenderer implements PreviewRenderer {
             const onAbort = (): void => {
                 this.liveModal?.forceResolve("aborted");
             };
-            const modal = new WriteActionPreviewModal(this.app, spec, (outcome) => {
+            const modal = new WriteActionPreviewModal(this.app, spec, (outcome, warnings) => {
                 cleanup();
-                resolve({ outcome });
+                resolve(warnings && warnings.length > 0
+                    ? { outcome, renderWarnings: warnings }
+                    : { outcome });
             });
             this.liveModal = modal;
             if (options?.signal) {

--- a/src/ai-services/write-action-framework/runtime-integration.spec.ts
+++ b/src/ai-services/write-action-framework/runtime-integration.spec.ts
@@ -1,0 +1,496 @@
+import { describe, expect, it, jest } from "@jest/globals";
+
+import type {
+    AgentCapabilityContext,
+    AgentCapabilityResult,
+} from "../capability-types";
+import type {
+    ChatToolName,
+    ChatToolPermission,
+    ChatToolSourceBoundary,
+} from "../chat-tool-types";
+import type { SourceRecordKind } from "../chat-types";
+import {
+    createActionExecutor,
+    createSelfWriteRegistry,
+    SELF_WRITE_WINDOW_MS,
+    type ActionExecutorOptions,
+    type FsProbe,
+} from "./runtime-integration";
+import type { PreviewRenderer } from "./preview-modal";
+import type {
+    ConfirmationOutcome,
+    DebugEvent,
+    DebugObserver,
+    PreviewSpec,
+    WriteActionCapability,
+} from "./types";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Test helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+function makeContext(overrides: Partial<AgentCapabilityContext> = {}): AgentCapabilityContext {
+    return {
+        plugin: {} as AgentCapabilityContext["plugin"],
+        turnId: "turn-1",
+        ...overrides,
+    };
+}
+
+function makeFsProbe(existsMap: Record<string, boolean> = {}): FsProbe {
+    return {
+        exists: jest.fn(async (path: string) => existsMap[path] ?? false) as FsProbe["exists"],
+    };
+}
+
+function makeObserver(events: DebugEvent[]): DebugObserver {
+    return { emit: (event) => events.push(event) };
+}
+
+function makeRenderer(outcomes: ConfirmationOutcome[]): PreviewRenderer {
+    let i = 0;
+    return {
+        show: jest.fn(async () => {
+            const o = outcomes[i++] ?? "confirmed";
+            return { outcome: o };
+        }) as PreviewRenderer["show"],
+    };
+}
+
+function makeCapability(
+    overrides: Partial<WriteActionCapability> = {},
+    spec: Partial<PreviewSpec> = {},
+): WriteActionCapability {
+    const previewSpec: PreviewSpec = {
+        target: { path: ".pagelet/foo.md", category: "pagelet-review-note" },
+        contentMarkdown: "# Body",
+        impact: "Creates 1 file",
+        risk: "None",
+        action: "Create .pagelet/foo.md",
+        ...spec,
+    };
+    // ChatToolName / ChatToolPermission / etc. are string-literal unions of the
+    // shipped tool names. Tests use a placeholder name + assertions to opt out.
+    const cap: WriteActionCapability = {
+        name: "test.write_action" as ChatToolName,
+        description: "test",
+        inputSchema: { type: "object", properties: {}, required: [], additionalProperties: false },
+        plannerGuidance: [],
+        kind: "action",
+        origin: "core",
+        providerId: "test-provider",
+        permission: "write",
+        sourceBoundary: "vault",
+        cost: "free",
+        platform: "both",
+        outputBudgetChars: 0,
+        timeoutMs: 30_000,
+        requiresConfirmation: true,
+        executionMode: "sequential",
+        failureBehavior: "recoverable",
+        statusMessageText: "writing",
+        sourceRecordKind: "context-used" as SourceRecordKind,
+        actionFamily: "create-file",
+        targetCategory: "pagelet-review-note",
+        targetConfinement: {
+            allowedRoots: [".pagelet/"],
+            allowedExtensions: [".md"],
+            maxPathLength: 200,
+        },
+        toProviderSchema: () => ({
+            type: "function",
+            function: {
+                name: "test.write_action",
+                description: "test",
+                parameters: { type: "object", properties: {}, required: [], additionalProperties: false },
+            },
+        }),
+        toRegistryDefinition: () => ({
+            name: "test.write_action" as ChatToolName,
+            description: "test",
+            inputSchema: { type: "object", properties: {}, required: [], additionalProperties: false },
+            plannerGuidance: [],
+            permission: "read-only" as ChatToolPermission, // registry def uses ChatToolPermission only
+            cost: "free",
+            outputBudgetChars: 0,
+            requiresConfirmation: true,
+            failureBehavior: "recoverable",
+            statusMessage: "writing",
+            sourceBoundary: "read-only-tool" as ChatToolSourceBoundary,
+        }),
+        execute: async () => {
+            throw new Error("WriteActionCapability.execute must not be called directly (use ActionExecutor)");
+        },
+        buildPreview: jest.fn(async () => previewSpec) as WriteActionCapability["buildPreview"],
+        executeWrite: jest.fn(async () => ({
+            status: "ok",
+            observation: { createdPath: ".pagelet/foo.md" },
+            sourceRecords: [],
+            inputSummary: "wrote",
+            sources: [],
+        })) as WriteActionCapability["executeWrite"],
+        ...overrides,
+    };
+    return cap;
+}
+
+function defaultExecutorOptions(overrides: Partial<ActionExecutorOptions> = {}): ActionExecutorOptions {
+    return {
+        previewRenderer: makeRenderer(["confirmed"]),
+        fsProbe: makeFsProbe({ ".pagelet": true }),
+        debugObserver: makeObserver([]),
+        runIdFactory: () => "run-x",
+        now: () => 1000,
+        // No-op timer keeps the auto-created SelfWriteRegistry from leaking
+        // real setTimeouts that prevent Jest workers from exiting cleanly.
+        selfWrite: createSelfWriteRegistry({
+            setTimer: () => ({ id: 1 }),
+            clearTimer: () => undefined,
+        }),
+        ...overrides,
+    };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Self-Write Set
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("createSelfWriteRegistry (framework SDD §5.3)", () => {
+    it("marks and reports recent self-writes", () => {
+        const reg = createSelfWriteRegistry();
+        reg.markSelfWrite(".pagelet/foo.md");
+        expect(reg.isRecentSelfWrite(".pagelet/foo.md")).toBe(true);
+        expect(reg.isRecentSelfWrite(".pagelet/bar.md")).toBe(false);
+        reg.dispose();
+    });
+
+    it("auto-expires entries after the TTL window via injected timer", () => {
+        const timers: Array<{ ms: number; cb: () => void }> = [];
+        const reg = createSelfWriteRegistry({
+            windowMs: 5_000,
+            setTimer: (cb, ms) => {
+                const handle = { ms, cb };
+                timers.push(handle);
+                return handle;
+            },
+            clearTimer: () => undefined,
+        });
+        reg.markSelfWrite(".pagelet/foo.md");
+        expect(reg.isRecentSelfWrite(".pagelet/foo.md")).toBe(true);
+        expect(timers).toHaveLength(1);
+        expect(timers[0].ms).toBe(5_000);
+        // Fire the TTL callback manually.
+        timers[0].cb();
+        expect(reg.isRecentSelfWrite(".pagelet/foo.md")).toBe(false);
+    });
+
+    it("re-marking refreshes the TTL (cancels prior timer)", () => {
+        const cancelled: unknown[] = [];
+        const reg = createSelfWriteRegistry({
+            setTimer: () => ({ id: Math.random() }),
+            clearTimer: (h) => cancelled.push(h),
+        });
+        reg.markSelfWrite(".pagelet/foo.md");
+        reg.markSelfWrite(".pagelet/foo.md");
+        expect(cancelled).toHaveLength(1);
+        reg.dispose();
+    });
+
+    it("dispose clears all paths and pending timers", () => {
+        const cancelled: unknown[] = [];
+        const reg = createSelfWriteRegistry({
+            setTimer: () => ({ id: Math.random() }),
+            clearTimer: (h) => cancelled.push(h),
+        });
+        reg.markSelfWrite("a.md");
+        reg.markSelfWrite("b.md");
+        expect(reg.snapshot().sort()).toEqual(["a.md", "b.md"]);
+        reg.dispose();
+        expect(reg.snapshot()).toEqual([]);
+        expect(cancelled.length).toBe(2);
+        // Subsequent isRecentSelfWrite returns false after dispose.
+        expect(reg.isRecentSelfWrite("a.md")).toBe(false);
+    });
+
+    it("default window is SELF_WRITE_WINDOW_MS (5s)", () => {
+        let ms = -1;
+        createSelfWriteRegistry({
+            setTimer: (_cb, t) => {
+                ms = t;
+                return { id: 1 };
+            },
+            clearTimer: () => undefined,
+        }).markSelfWrite("a.md");
+        expect(ms).toBe(SELF_WRITE_WINDOW_MS);
+    });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ActionExecutor — 4-gate happy path
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("ActionExecutor (4-gate orchestration, framework SDD §3.2)", () => {
+    it("runs the happy path: confinement → preview → stale → execute, emitting in order", async () => {
+        const events: DebugEvent[] = [];
+        const cap = makeCapability();
+        const options = defaultExecutorOptions({ debugObserver: makeObserver(events) });
+        const exec = createActionExecutor(options);
+        const result = await exec.execute(cap, { foo: 1 }, makeContext());
+
+        expect(result.status).toBe("ok");
+        const types = events.map((e) => e.type);
+        expect(types).toEqual([
+            "gate.target-confinement.ok",
+            "gate.preview.shown",
+            "gate.confirmation.received",
+            "gate.stale-reread.ok",
+            "execute.ok",
+        ]);
+        // capability.executeWrite was called with hooks containing markSelfWrite
+        expect((cap.executeWrite as jest.Mock)).toHaveBeenCalledTimes(1);
+    });
+
+    it("calls buildPreview before Gate 1 and feeds target.path into confinement", async () => {
+        const cap = makeCapability();
+        const exec = createActionExecutor(defaultExecutorOptions());
+        await exec.execute(cap, { foo: 1 }, makeContext());
+        expect((cap.buildPreview as jest.Mock)).toHaveBeenCalledTimes(1);
+    });
+
+    it("marks the normalized target as self-written before executeWrite runs", async () => {
+        const seenInsideExecute: string[] = [];
+        const selfWrite = createSelfWriteRegistry({
+            setTimer: () => ({ id: 1 }),
+            clearTimer: () => undefined,
+        });
+        const cap = makeCapability({
+            executeWrite: jest.fn(async () => {
+                // Inside executeWrite, the framework should have already marked the target.
+                seenInsideExecute.push(...selfWrite.snapshot());
+                return {
+                    status: "ok" as const,
+                    observation: null,
+                    sourceRecords: [],
+                    inputSummary: "ok",
+                    sources: [],
+                };
+            }) as WriteActionCapability["executeWrite"],
+        });
+        const options = defaultExecutorOptions({ selfWrite });
+        await createActionExecutor(options).execute(cap, {}, makeContext());
+        expect(seenInsideExecute).toContain(".pagelet/foo.md");
+    });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ActionExecutor — gate-rejection paths
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("ActionExecutor (gate rejection paths)", () => {
+    it("returns failure + emits gate.target-confinement.reject when target outside allowlist", async () => {
+        const events: DebugEvent[] = [];
+        const cap = makeCapability(
+            {},
+            { target: { path: "/etc/passwd", category: "pagelet-review-note" } },
+        );
+        const exec = createActionExecutor(defaultExecutorOptions({ debugObserver: makeObserver(events) }));
+        const result = await exec.execute(cap, {}, makeContext());
+        expect(result.status).toBe("failed");
+        const types = events.map((e) => e.type);
+        expect(types).toEqual(["gate.target-confinement.reject"]);
+        expect(events[0].errorCategory).toBe("rejected_at_confinement");
+        expect(events[0].extra?.reason).toBe("absolute_path");
+        expect((cap.executeWrite as jest.Mock)).not.toHaveBeenCalled();
+    });
+
+    it("returns failure + emits gate.confirmation.received with outcome when user cancels", async () => {
+        const events: DebugEvent[] = [];
+        const cap = makeCapability();
+        const exec = createActionExecutor(defaultExecutorOptions({
+            debugObserver: makeObserver(events),
+            previewRenderer: makeRenderer(["cancelled"]),
+        }));
+        const result = await exec.execute(cap, {}, makeContext());
+        expect(result.status).toBe("failed");
+        expect(result.error).toMatch(/cancelled/);
+        const types = events.map((e) => e.type);
+        expect(types).toEqual([
+            "gate.target-confinement.ok",
+            "gate.preview.shown",
+            "gate.confirmation.received",
+        ]);
+        const confirmation = events[2];
+        expect(confirmation.extra?.outcome).toBe("cancelled");
+        expect((cap.executeWrite as jest.Mock)).not.toHaveBeenCalled();
+    });
+
+    it("returns failure for closed/aborted outcomes (still emits gate.confirmation.received)", async () => {
+        for (const outcome of ["closed", "aborted"] as const) {
+            const events: DebugEvent[] = [];
+            const cap = makeCapability();
+            const exec = createActionExecutor(defaultExecutorOptions({
+                debugObserver: makeObserver(events),
+                previewRenderer: makeRenderer([outcome]),
+            }));
+            const result = await exec.execute(cap, {}, makeContext());
+            expect(result.status).toBe("failed");
+            expect(events.find((e) => e.type === "gate.confirmation.received")?.extra?.outcome).toBe(outcome);
+            expect((cap.executeWrite as jest.Mock)).not.toHaveBeenCalled();
+        }
+    });
+
+    it("returns failure + emits gate.stale-reread.drift when target appears between preview and execute", async () => {
+        const events: DebugEvent[] = [];
+        const existsMap: Record<string, boolean> = { ".pagelet": true, ".pagelet/foo.md": false };
+        const fsProbe: FsProbe = {
+            exists: jest.fn(async (path: string) => existsMap[path] ?? false) as FsProbe["exists"],
+        };
+        const cap = makeCapability();
+        const exec = createActionExecutor(defaultExecutorOptions({
+            debugObserver: makeObserver(events),
+            fsProbe,
+        }));
+        // Schedule a flip: after Gate 2 returns confirmed, the target "appears"
+        // before Gate 3 re-reads. We do this by toggling the map after the
+        // renderer resolves.
+        const renderer: PreviewRenderer = {
+            show: jest.fn(async () => {
+                existsMap[".pagelet/foo.md"] = true;
+                return { outcome: "confirmed" as ConfirmationOutcome };
+            }) as PreviewRenderer["show"],
+        };
+        const exec2 = createActionExecutor({
+            ...defaultExecutorOptions({ debugObserver: makeObserver(events), fsProbe }),
+            previewRenderer: renderer,
+        });
+        const result = await exec2.execute(cap, {}, makeContext());
+        expect(result.status).toBe("failed");
+        const driftEvent = events.find((e) => e.type === "gate.stale-reread.drift");
+        expect(driftEvent).toBeDefined();
+        expect(driftEvent?.errorCategory).toBe("stale_drift");
+        expect((driftEvent?.extra as { drift?: Record<string, boolean> } | undefined)?.drift?.targetAppeared).toBe(true);
+    });
+
+    it("captures buildPreview throwing as execute.fail with stage=buildPreview", async () => {
+        const events: DebugEvent[] = [];
+        const cap = makeCapability({
+            buildPreview: jest.fn(async () => {
+                throw new Error("preview synthesis failed");
+            }) as WriteActionCapability["buildPreview"],
+        });
+        const exec = createActionExecutor(defaultExecutorOptions({ debugObserver: makeObserver(events) }));
+        const result = await exec.execute(cap, {}, makeContext());
+        expect(result.status).toBe("failed");
+        const evt = events.find((e) => e.type === "execute.fail");
+        expect(evt?.extra?.stage).toBe("buildPreview");
+    });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ActionExecutor — execute + rollback
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("ActionExecutor (execute & rollback)", () => {
+    it("emits execute.fail + rollback.ok when executeWrite throws and rollback succeeds", async () => {
+        const events: DebugEvent[] = [];
+        const rollback = jest.fn(async () => undefined) as WriteActionCapability["rollback"];
+        const cap = makeCapability({
+            executeWrite: jest.fn(async () => {
+                throw new Error("disk full");
+            }) as WriteActionCapability["executeWrite"],
+            rollback,
+        });
+        const exec = createActionExecutor(defaultExecutorOptions({ debugObserver: makeObserver(events) }));
+        const result = await exec.execute(cap, {}, makeContext());
+        expect(result.status).toBe("failed");
+        const types = events.map((e) => e.type);
+        expect(types).toContain("execute.fail");
+        expect(types).toContain("rollback.ok");
+        expect((rollback as jest.Mock)).toHaveBeenCalledTimes(1);
+        const failEvent = events.find((e) => e.type === "execute.fail");
+        expect(failEvent?.errorCategory).toBe("fs_error");
+    });
+
+    it("emits rollback.fail when executeWrite throws AND rollback throws (no cascade)", async () => {
+        const events: DebugEvent[] = [];
+        const cap = makeCapability({
+            executeWrite: jest.fn(async () => {
+                throw new Error("primary failure");
+            }) as WriteActionCapability["executeWrite"],
+            rollback: jest.fn(async () => {
+                throw new Error("rollback exploded");
+            }) as WriteActionCapability["rollback"],
+        });
+        const exec = createActionExecutor(defaultExecutorOptions({ debugObserver: makeObserver(events) }));
+        const result = await exec.execute(cap, {}, makeContext());
+        expect(result.status).toBe("failed");
+        const rollbackEvt = events.find((e) => e.type === "rollback.fail");
+        expect(rollbackEvt?.extra?.cascade).toBe(true);
+    });
+
+    it("skips rollback emission when capability has no rollback fn (capability handles its own cleanup)", async () => {
+        const events: DebugEvent[] = [];
+        const cap = makeCapability({
+            executeWrite: jest.fn(async () => {
+                throw new Error("oops");
+            }) as WriteActionCapability["executeWrite"],
+        });
+        const exec = createActionExecutor(defaultExecutorOptions({ debugObserver: makeObserver(events) }));
+        await exec.execute(cap, {}, makeContext());
+        const types = events.map((e) => e.type);
+        expect(types).toContain("execute.fail");
+        expect(types).not.toContain("rollback.ok");
+        expect(types).not.toContain("rollback.fail");
+    });
+
+    it("emits execute.fail + rollback when capability returns non-ok status without throwing", async () => {
+        const events: DebugEvent[] = [];
+        const rollback = jest.fn(async () => undefined) as WriteActionCapability["rollback"];
+        const cap = makeCapability({
+            executeWrite: jest.fn(async (): Promise<AgentCapabilityResult> => ({
+                status: "failed",
+                observation: null,
+                sourceRecords: [],
+                inputSummary: "fail",
+                sources: [],
+                error: "capability-reported error",
+            })) as WriteActionCapability["executeWrite"],
+            rollback,
+        });
+        const exec = createActionExecutor(defaultExecutorOptions({ debugObserver: makeObserver(events) }));
+        const result = await exec.execute(cap, {}, makeContext());
+        expect(result.status).toBe("failed");
+        expect(result.error).toBe("capability-reported error");
+        expect(events.map((e) => e.type)).toContain("execute.fail");
+        expect((rollback as jest.Mock)).toHaveBeenCalled();
+    });
+
+    it("threads context.signal into previewRenderer.show options", async () => {
+        const controller = new AbortController();
+        const showSpy = jest.fn(async (..._args: unknown[]) => ({
+            outcome: "confirmed" as ConfirmationOutcome,
+        })) as PreviewRenderer["show"];
+        const renderer: PreviewRenderer = { show: showSpy };
+        const cap = makeCapability();
+        const exec = createActionExecutor(defaultExecutorOptions({ previewRenderer: renderer }));
+        await exec.execute(cap, {}, makeContext({ signal: controller.signal }));
+        expect((showSpy as jest.Mock)).toHaveBeenCalled();
+        const call = (showSpy as jest.Mock).mock.calls[0] as unknown[];
+        const opts = call[1] as { signal?: AbortSignal } | undefined;
+        expect(opts?.signal).toBe(controller.signal);
+    });
+
+    it("works without fsProbe (skips collision + stale reread sub-checks)", async () => {
+        const events: DebugEvent[] = [];
+        const cap = makeCapability();
+        const exec = createActionExecutor(defaultExecutorOptions({
+            fsProbe: undefined,
+            debugObserver: makeObserver(events),
+        }));
+        const result = await exec.execute(cap, {}, makeContext());
+        expect(result.status).toBe("ok");
+        const stale = events.find((e) => e.type === "gate.stale-reread.ok");
+        expect(stale?.extra?.skipped).toBe(true);
+    });
+});

--- a/src/ai-services/write-action-framework/runtime-integration.spec.ts
+++ b/src/ai-services/write-action-framework/runtime-integration.spec.ts
@@ -63,13 +63,30 @@ function makeCapability(
     spec: Partial<PreviewSpec> = {},
 ): WriteActionCapability {
     const previewSpec: PreviewSpec = {
-        target: { path: ".pagelet/foo.md", category: "pagelet-review-note" },
-        contentMarkdown: "# Body",
-        impact: "Creates 1 file",
-        risk: "None",
-        action: "Create .pagelet/foo.md",
+        operationType: "create-file",
+        actionFamily: "pagelet-review-note",
+        capabilityId: "test.write_action",
+        target: {
+            kind: "vault-path",
+            displayPath: ".pagelet/foo.md",
+            folder: ".pagelet/",
+            filename: "foo.md",
+        },
+        contentPreview: {
+            format: "markdown",
+            body: "# Body",
+            byteSize: 6,
+        },
+        impact: {
+            usesAiProvider: false,
+            usesAiCredits: false,
+            affectsExternalState: false,
+        },
+        riskNotes: [],
+        confirmCopy: { confirmLabel: "Confirm", cancelLabel: "Cancel" },
         ...spec,
     };
+    const initialTargetPath = previewSpec.target.displayPath;
     // ChatToolName / ChatToolPermission / etc. are string-literal unions of the
     // shipped tool names. Tests use a placeholder name + assertions to opt out.
     const cap: WriteActionCapability = {
@@ -122,6 +139,8 @@ function makeCapability(
         execute: async () => {
             throw new Error("WriteActionCapability.execute must not be called directly (use ActionExecutor)");
         },
+        getTargetPath: ((): WriteActionCapability["getTargetPath"] =>
+            (() => initialTargetPath))(),
         buildPreview: jest.fn(async () => previewSpec) as WriteActionCapability["buildPreview"],
         executeWrite: jest.fn(async () => ({
             status: "ok",
@@ -258,6 +277,27 @@ describe("ActionExecutor (4-gate orchestration, framework SDD §3.2)", () => {
         expect((cap.buildPreview as jest.Mock)).toHaveBeenCalledTimes(1);
     });
 
+    it("re-marks self-write on the success path so a slow executeWrite cannot age out the TTL (Fix #7)", async () => {
+        const markCalls: string[] = [];
+        const selfWrite = createSelfWriteRegistry({
+            setTimer: () => ({ id: 1 }),
+            clearTimer: () => undefined,
+        });
+        // Wrap selfWrite to record every markSelfWrite invocation.
+        const wrapped = {
+            ...selfWrite,
+            markSelfWrite: (path: string) => {
+                markCalls.push(path);
+                selfWrite.markSelfWrite(path);
+            },
+        };
+        const cap = makeCapability();
+        await createActionExecutor(defaultExecutorOptions({ selfWrite: wrapped }))
+            .execute(cap, {}, makeContext());
+        // Two marks for the same path: one pre-execute, one post-execute (Fix #7).
+        expect(markCalls.filter((p) => p === ".pagelet/foo.md")).toHaveLength(2);
+    });
+
     it("marks the normalized target as self-written before executeWrite runs", async () => {
         const seenInsideExecute: string[] = [];
         const selfWrite = createSelfWriteRegistry({
@@ -290,10 +330,9 @@ describe("ActionExecutor (4-gate orchestration, framework SDD §3.2)", () => {
 describe("ActionExecutor (gate rejection paths)", () => {
     it("returns failure + emits gate.target-confinement.reject when target outside allowlist", async () => {
         const events: DebugEvent[] = [];
-        const cap = makeCapability(
-            {},
-            { target: { path: "/etc/passwd", category: "pagelet-review-note" } },
-        );
+        const cap = makeCapability({
+            getTargetPath: () => "/etc/passwd",
+        });
         const exec = createActionExecutor(defaultExecutorOptions({ debugObserver: makeObserver(events) }));
         const result = await exec.execute(cap, {}, makeContext());
         expect(result.status).toBe("failed");
@@ -302,6 +341,9 @@ describe("ActionExecutor (gate rejection paths)", () => {
         expect(events[0].errorCategory).toBe("rejected_at_confinement");
         expect(events[0].extra?.reason).toBe("absolute_path");
         expect((cap.executeWrite as jest.Mock)).not.toHaveBeenCalled();
+        // Fix #3: buildPreview is NOT called when getTargetPath fails
+        // confinement, since Gate 1 runs first.
+        expect((cap.buildPreview as jest.Mock)).not.toHaveBeenCalled();
     });
 
     it("returns failure + emits gate.confirmation.received with outcome when user cancels", async () => {
@@ -325,8 +367,8 @@ describe("ActionExecutor (gate rejection paths)", () => {
         expect((cap.executeWrite as jest.Mock)).not.toHaveBeenCalled();
     });
 
-    it("returns failure for closed/aborted outcomes (still emits gate.confirmation.received)", async () => {
-        for (const outcome of ["closed", "aborted"] as const) {
+    it("returns failure for cancelled/aborted outcomes (still emits gate.confirmation.received)", async () => {
+        for (const outcome of ["cancelled", "aborted"] as const) {
             const events: DebugEvent[] = [];
             const cap = makeCapability();
             const exec = createActionExecutor(defaultExecutorOptions({
@@ -368,7 +410,7 @@ describe("ActionExecutor (gate rejection paths)", () => {
         expect(result.status).toBe("failed");
         const driftEvent = events.find((e) => e.type === "gate.stale-reread.drift");
         expect(driftEvent).toBeDefined();
-        expect(driftEvent?.errorCategory).toBe("stale_drift");
+        expect(driftEvent?.errorCategory).toBe("stale_target");
         expect((driftEvent?.extra as { drift?: Record<string, boolean> } | undefined)?.drift?.targetAppeared).toBe(true);
     });
 
@@ -384,6 +426,59 @@ describe("ActionExecutor (gate rejection paths)", () => {
         expect(result.status).toBe("failed");
         const evt = events.find((e) => e.type === "execute.fail");
         expect(evt?.extra?.stage).toBe("buildPreview");
+        expect(evt?.errorCategory).toBe("user_aborted");
+    });
+
+    it("returns failure + emits gate.target-confinement.reject when getTargetPath throws (Fix #5)", async () => {
+        const events: DebugEvent[] = [];
+        const cap = makeCapability({
+            getTargetPath: () => {
+                throw new Error("input missing target");
+            },
+        });
+        const exec = createActionExecutor(defaultExecutorOptions({ debugObserver: makeObserver(events) }));
+        const result = await exec.execute(cap, {}, makeContext());
+        expect(result.status).toBe("failed");
+        const evt = events.find((e) => e.type === "gate.target-confinement.reject");
+        expect(evt?.extra?.stage).toBe("getTargetPath");
+        expect(evt?.errorCategory).toBe("user_aborted");
+        expect((cap.buildPreview as jest.Mock)).not.toHaveBeenCalled();
+        expect((cap.executeWrite as jest.Mock)).not.toHaveBeenCalled();
+    });
+
+    it("rejects when spec.target.displayPath disagrees with getTargetPath (Fix #3)", async () => {
+        const events: DebugEvent[] = [];
+        const cap = makeCapability(
+            { getTargetPath: () => ".pagelet/foo.md" },
+            { target: { kind: "vault-path", displayPath: ".pagelet/other.md", folder: ".pagelet/", filename: "other.md" } },
+        );
+        const exec = createActionExecutor(defaultExecutorOptions({ debugObserver: makeObserver(events) }));
+        const result = await exec.execute(cap, {}, makeContext());
+        expect(result.status).toBe("failed");
+        const evt = events.find((e) => e.type === "gate.target-confinement.reject");
+        expect(evt?.errorCategory).toBe("rejected_at_confinement");
+        expect(evt?.extra?.reason).toBe("path mismatch between getTargetPath and buildPreview");
+        expect((cap.executeWrite as jest.Mock)).not.toHaveBeenCalled();
+    });
+
+    it("returns failure + emits gate.confirmation.received with renderWarnings when preview render throws (Fix #5)", async () => {
+        const events: DebugEvent[] = [];
+        const renderer: PreviewRenderer = {
+            show: jest.fn(async () => {
+                throw new Error("modal mount exploded");
+            }) as PreviewRenderer["show"],
+        };
+        const cap = makeCapability();
+        const exec = createActionExecutor(defaultExecutorOptions({
+            debugObserver: makeObserver(events),
+            previewRenderer: renderer,
+        }));
+        const result = await exec.execute(cap, {}, makeContext());
+        expect(result.status).toBe("failed");
+        const evt = events.find((e) => e.type === "gate.confirmation.received");
+        expect(evt?.errorCategory).toBe("preview_render_failed");
+        expect(evt?.extra?.outcome).toBe("aborted");
+        expect((cap.executeWrite as jest.Mock)).not.toHaveBeenCalled();
     });
 });
 
@@ -429,19 +524,104 @@ describe("ActionExecutor (execute & rollback)", () => {
         expect(rollbackEvt?.extra?.cascade).toBe(true);
     });
 
-    it("skips rollback emission when capability has no rollback fn (capability handles its own cleanup)", async () => {
+    it("skips rollback emission when capability has no rollback fn AND fsProbe lacks remove (no safety net wired)", async () => {
         const events: DebugEvent[] = [];
         const cap = makeCapability({
             executeWrite: jest.fn(async () => {
                 throw new Error("oops");
             }) as WriteActionCapability["executeWrite"],
         });
+        // Default fsProbe (makeFsProbe) lacks `remove`, so the framework
+        // safety net cannot run; rollback emit chain stays silent.
         const exec = createActionExecutor(defaultExecutorOptions({ debugObserver: makeObserver(events) }));
         await exec.execute(cap, {}, makeContext());
         const types = events.map((e) => e.type);
         expect(types).toContain("execute.fail");
         expect(types).not.toContain("rollback.ok");
         expect(types).not.toContain("rollback.fail");
+    });
+
+    it("auto-removes create-file target via fsProbe.remove when executeWrite throws (Fix #4)", async () => {
+        const events: DebugEvent[] = [];
+        const removeCalls: string[] = [];
+        const fsProbe: FsProbe = {
+            exists: jest.fn(async (path: string) => path === ".pagelet") as FsProbe["exists"],
+            remove: jest.fn(async (path: string) => {
+                removeCalls.push(path);
+            }) as NonNullable<FsProbe["remove"]>,
+        };
+        const cap = makeCapability({
+            executeWrite: jest.fn(async () => {
+                throw new Error("disk full");
+            }) as WriteActionCapability["executeWrite"],
+        });
+        const exec = createActionExecutor(defaultExecutorOptions({
+            debugObserver: makeObserver(events),
+            fsProbe,
+        }));
+        const result = await exec.execute(cap, {}, makeContext());
+        expect(result.status).toBe("failed");
+        expect(removeCalls).toEqual([".pagelet/foo.md"]);
+        const rollbackOk = events.find(
+            (e) => e.type === "rollback.ok" && e.extra?.layer === "framework",
+        );
+        expect(rollbackOk).toBeDefined();
+        expect(rollbackOk?.extra?.normalizedPath).toBe(".pagelet/foo.md");
+        expect(rollbackOk?.extra?.cascade).toBe(false);
+    });
+
+    it("runs capability rollback AND framework auto-remove when both wired (Fix #4 cascade)", async () => {
+        const events: DebugEvent[] = [];
+        const fsProbe: FsProbe = {
+            exists: jest.fn(async (path: string) => path === ".pagelet") as FsProbe["exists"],
+            remove: jest.fn(async () => undefined) as NonNullable<FsProbe["remove"]>,
+        };
+        const rollback = jest.fn(async () => undefined) as WriteActionCapability["rollback"];
+        const cap = makeCapability({
+            executeWrite: jest.fn(async () => {
+                throw new Error("nope");
+            }) as WriteActionCapability["executeWrite"],
+            rollback,
+        });
+        const exec = createActionExecutor(defaultExecutorOptions({
+            debugObserver: makeObserver(events),
+            fsProbe,
+        }));
+        await exec.execute(cap, {}, makeContext());
+        const okEvents = events.filter((e) => e.type === "rollback.ok");
+        expect(okEvents).toHaveLength(2);
+        const layers = okEvents.map((e) => e.extra?.layer);
+        expect(layers).toEqual(expect.arrayContaining(["capability", "framework"]));
+        const frameworkEvt = okEvents.find((e) => e.extra?.layer === "framework");
+        expect(frameworkEvt?.extra?.cascade).toBe(true);
+        expect((rollback as jest.Mock)).toHaveBeenCalledTimes(1);
+        expect((fsProbe.remove as jest.Mock)).toHaveBeenCalledWith(".pagelet/foo.md");
+    });
+
+    it("emits rollback.fail layer=framework with fs_error when fsProbe.remove throws (Fix #4)", async () => {
+        const events: DebugEvent[] = [];
+        const fsProbe: FsProbe = {
+            exists: jest.fn(async (path: string) => path === ".pagelet") as FsProbe["exists"],
+            remove: jest.fn(async () => {
+                throw new Error("permission denied");
+            }) as NonNullable<FsProbe["remove"]>,
+        };
+        const cap = makeCapability({
+            executeWrite: jest.fn(async () => {
+                throw new Error("disk gone");
+            }) as WriteActionCapability["executeWrite"],
+        });
+        const exec = createActionExecutor(defaultExecutorOptions({
+            debugObserver: makeObserver(events),
+            fsProbe,
+        }));
+        await exec.execute(cap, {}, makeContext());
+        const failEvt = events.find(
+            (e) => e.type === "rollback.fail" && e.extra?.layer === "framework",
+        );
+        expect(failEvt).toBeDefined();
+        expect(failEvt?.errorCategory).toBe("fs_error");
+        expect(failEvt?.extra?.normalizedPath).toBe(".pagelet/foo.md");
     });
 
     it("emits execute.fail + rollback when capability returns non-ok status without throwing", async () => {

--- a/src/ai-services/write-action-framework/runtime-integration.ts
+++ b/src/ai-services/write-action-framework/runtime-integration.ts
@@ -1,0 +1,425 @@
+/**
+ * Runtime integration glue — framework SDD §3 + §5.3 + §6.
+ *
+ * Two responsibilities:
+ *
+ *   1. **Self-Write Set** (`createSelfWriteRegistry`): TTL-bounded record of
+ *      paths the framework has just written, so a caller's `vault.on("modify")`
+ *      listener can skip its own ripple. v1 window = 5s per SDD §5.3.
+ *      Belt-and-suspenders for D029 R3 assumption (vault.adapter.write may bypass
+ *      modify event); if that assumption is ever broken upstream, this Set
+ *      prevents a self-summoning loop.
+ *
+ *   2. **ActionExecutor** (`createActionExecutor`): 4-gate orchestrator that
+ *      sequences a {@link WriteActionCapability} through target-confinement →
+ *      preview-confirmation → stale-reread → executeWrite, emitting the
+ *      structured debug events at each transition. Rollback is invoked on
+ *      execute failure when the capability declares one.
+ *
+ * The executor is pure-ish: it depends on three injected services
+ * (PreviewRenderer, fsProbe, DebugObserver) plus a run-id factory. Nothing is
+ * module-scope, so multiple PA runtimes can co-exist (test isolation).
+ */
+
+import type {
+    AgentCapabilityContext,
+    AgentCapabilityResult,
+} from "../capability-types";
+import {
+    NOOP_DEBUG_OBSERVER,
+} from "./debug-observer";
+import type { PreviewRenderer } from "./preview-modal";
+import {
+    checkStaleReread,
+    takeSnapshot,
+    type StaleReadProbe,
+} from "./stale-reread";
+import {
+    validateTargetConfinement,
+    type ConfinementFsProbe,
+} from "./target-confinement";
+import type {
+    DebugEvent,
+    DebugEventType,
+    DebugObserver,
+    PreviewSpec,
+    WriteActionCapability,
+    WriteActionExecuteHooks,
+} from "./types";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Self-Write Set
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Default window during which a path is considered "recently self-written". */
+export const SELF_WRITE_WINDOW_MS = 5_000;
+
+export interface SelfWriteRegistry {
+    markSelfWrite(path: string): void;
+    isRecentSelfWrite(path: string): boolean;
+    /**
+     * Clear all entries + cancel pending TTL timers. MUST be called on plugin
+     * unload so dangling setTimeouts don't keep the runtime alive.
+     */
+    dispose(): void;
+    /** Currently-known paths (for diagnostics / tests). */
+    snapshot(): string[];
+}
+
+export interface SelfWriteRegistryOptions {
+    windowMs?: number;
+    /** Test seam: override Date.now / setTimeout / clearTimeout. */
+    now?: () => number;
+    setTimer?: (cb: () => void, ms: number) => unknown;
+    clearTimer?: (handle: unknown) => void;
+}
+
+export function createSelfWriteRegistry(options: SelfWriteRegistryOptions = {}): SelfWriteRegistry {
+    const windowMs = options.windowMs ?? SELF_WRITE_WINDOW_MS;
+    const setTimer = options.setTimer ?? ((cb, ms) => setTimeout(cb, ms));
+    const clearTimer = options.clearTimer ?? ((h) => clearTimeout(h as ReturnType<typeof setTimeout>));
+    const paths = new Set<string>();
+    const timers = new Map<string, unknown>();
+
+    return {
+        markSelfWrite(path: string): void {
+            // Re-mark refreshes the TTL: cancel old timer, schedule a new one.
+            const existing = timers.get(path);
+            if (existing !== undefined) clearTimer(existing);
+            paths.add(path);
+            const handle = setTimer(() => {
+                paths.delete(path);
+                timers.delete(path);
+            }, windowMs);
+            timers.set(path, handle);
+        },
+        isRecentSelfWrite(path: string): boolean {
+            return paths.has(path);
+        },
+        dispose(): void {
+            for (const handle of timers.values()) {
+                clearTimer(handle);
+            }
+            timers.clear();
+            paths.clear();
+        },
+        snapshot(): string[] {
+            return Array.from(paths);
+        },
+    };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ActionExecutor — 4-gate orchestrator
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Joint FS adapter shape used by Gate 1 + Gate 3. Mirrors `vault.adapter.exists`. */
+export type FsProbe = ConfinementFsProbe & StaleReadProbe;
+
+export interface ActionExecutor {
+    /**
+     * Drive a single WriteActionCapability through all 4 gates. Returns the
+     * capability's AgentCapabilityResult on success, or a synthesized failure
+     * result when a gate rejects / the user declines.
+     */
+    execute(
+        capability: WriteActionCapability,
+        input: unknown,
+        context: AgentCapabilityContext,
+    ): Promise<AgentCapabilityResult>;
+}
+
+export interface ActionExecutorOptions {
+    previewRenderer: PreviewRenderer;
+    /**
+     * Filesystem probe used by Gate 1 (collision/folder) + Gate 3 (snapshot).
+     * If omitted, both gates skip their async FS sub-checks (sync confinement
+     * still runs). The Pagelet runtime should pass `app.vault.adapter`.
+     */
+    fsProbe?: FsProbe;
+    selfWrite?: SelfWriteRegistry;
+    debugObserver?: DebugObserver;
+    /** Test seam for deterministic ids. */
+    runIdFactory?: () => string;
+    /** Test seam for elapsed-time measurement. */
+    now?: () => number;
+}
+
+export function createActionExecutor(options: ActionExecutorOptions): ActionExecutor {
+    const previewRenderer = options.previewRenderer;
+    const fsProbe = options.fsProbe;
+    const selfWrite = options.selfWrite ?? createSelfWriteRegistry();
+    const debugObserver = options.debugObserver ?? NOOP_DEBUG_OBSERVER;
+    const now = options.now ?? Date.now;
+    const runIdFactory =
+        options.runIdFactory ??
+        (() => `run-${now()}-${Math.random().toString(36).slice(2, 8)}`);
+
+    function emit(
+        type: DebugEventType,
+        capability: WriteActionCapability,
+        runId: string,
+        turnId: string,
+        extras: Partial<DebugEvent> = {},
+    ): void {
+        const event: DebugEvent = {
+            type,
+            capabilityId: capability.name,
+            runId,
+            turnId,
+            ...extras,
+        };
+        try {
+            debugObserver.emit(event);
+        } catch {
+            // Best-effort: never let observer faults break the action lifecycle.
+        }
+    }
+
+    function failure(
+        capability: WriteActionCapability,
+        reason: string,
+        userSafeMessage?: string,
+    ): AgentCapabilityResult {
+        return {
+            status: "failed",
+            observation: null,
+            sourceRecords: [],
+            inputSummary: capability.name,
+            sources: [],
+            error: reason,
+            userSafeMessage,
+        };
+    }
+
+    return {
+        async execute(capability, input, context): Promise<AgentCapabilityResult> {
+            const runId = runIdFactory();
+            const turnId = context.turnId ?? "unknown";
+            const startedAt = now();
+
+            // ────────────────────────────────────────────────────────────────
+            // Gate 0: build preview first (pure per Step 0 contract). This gives
+            // us the target.path string used by Gate 1, without forcing
+            // capabilities to expose a separate getTargetPath() method.
+            // ────────────────────────────────────────────────────────────────
+            let spec: PreviewSpec;
+            try {
+                spec = await capability.buildPreview(input, context);
+            } catch (error) {
+                emit("execute.fail", capability, runId, turnId, {
+                    errorCategory: "unknown",
+                    extra: {
+                        stage: "buildPreview",
+                        message: error instanceof Error ? error.message : String(error),
+                    },
+                });
+                return failure(
+                    capability,
+                    `buildPreview threw: ${error instanceof Error ? error.message : String(error)}`,
+                );
+            }
+
+            // ────────────────────────────────────────────────────────────────
+            // Gate 1: target confinement
+            // ────────────────────────────────────────────────────────────────
+            const confinement = await validateTargetConfinement(
+                spec.target.path,
+                capability.targetConfinement,
+                fsProbe,
+            );
+            if (!confinement.ok) {
+                emit("gate.target-confinement.reject", capability, runId, turnId, {
+                    errorCategory: "rejected_at_confinement",
+                    extra: {
+                        reason: confinement.reason,
+                        detail: confinement.detail,
+                        candidatePath: spec.target.path,
+                        targetCategory: capability.targetCategory,
+                    },
+                });
+                return failure(
+                    capability,
+                    `target rejected at confinement: ${confinement.reason}`,
+                    "The proposed file path was rejected by safety checks.",
+                );
+            }
+            emit("gate.target-confinement.ok", capability, runId, turnId, {
+                extra: {
+                    normalizedPath: confinement.normalizedPath,
+                    targetCategory: capability.targetCategory,
+                },
+            });
+
+            // ────────────────────────────────────────────────────────────────
+            // Gate 2: preview-confirmation lifecycle
+            // (snapshot for Gate 3 captured at preview time per SDD §2.3)
+            // ────────────────────────────────────────────────────────────────
+            const snapshot = fsProbe
+                ? await takeSnapshot(confinement.normalizedPath, fsProbe, now)
+                : {
+                    targetPath: confinement.normalizedPath,
+                    folderExists: true,
+                    targetExists: false,
+                    capturedAt: now(),
+                };
+            emit("gate.preview.shown", capability, runId, turnId, {
+                extra: {
+                    targetCategory: capability.targetCategory,
+                    normalizedPath: confinement.normalizedPath,
+                    snapshotAt: snapshot.capturedAt,
+                },
+            });
+            const { outcome, renderWarnings } = await previewRenderer.show(spec, {
+                signal: context.signal,
+            });
+            emit("gate.confirmation.received", capability, runId, turnId, {
+                extra: {
+                    outcome,
+                    renderWarnings,
+                    targetCategory: capability.targetCategory,
+                },
+            });
+            if (outcome !== "confirmed") {
+                return failure(
+                    capability,
+                    `user did not confirm: ${outcome}`,
+                    outcome === "aborted" ? "Action was aborted." : undefined,
+                );
+            }
+
+            // ────────────────────────────────────────────────────────────────
+            // Gate 3: stale re-read (mode A)
+            // ────────────────────────────────────────────────────────────────
+            if (fsProbe) {
+                const stale = await checkStaleReread(snapshot, fsProbe, now);
+                if (stale.stale) {
+                    emit("gate.stale-reread.drift", capability, runId, turnId, {
+                        errorCategory: "stale_drift",
+                        extra: {
+                            drift: stale.drift,
+                            targetCategory: capability.targetCategory,
+                            normalizedPath: confinement.normalizedPath,
+                            snapshotAt: snapshot.capturedAt,
+                            checkedAt: stale.checkedAt,
+                        },
+                    });
+                    return failure(
+                        capability,
+                        "target snapshot drift detected before execute",
+                        "The file state changed while the preview was shown; the action was cancelled.",
+                    );
+                }
+                emit("gate.stale-reread.ok", capability, runId, turnId, {
+                    extra: {
+                        normalizedPath: confinement.normalizedPath,
+                        targetCategory: capability.targetCategory,
+                    },
+                });
+            } else {
+                // No probe → Gate 3 short-circuits as a successful check.
+                emit("gate.stale-reread.ok", capability, runId, turnId, {
+                    extra: {
+                        skipped: true,
+                        targetCategory: capability.targetCategory,
+                    },
+                });
+            }
+
+            // ────────────────────────────────────────────────────────────────
+            // Execute: real write happens inside capability.executeWrite.
+            // Framework marks self-write BEFORE delegating so the caller's
+            // modify listener (if any) sees the entry by the time the write
+            // event ripples back.
+            // ────────────────────────────────────────────────────────────────
+            const hooks: WriteActionExecuteHooks = {
+                markSelfWrite: (path: string) => selfWrite.markSelfWrite(path),
+            };
+            // Mark the framework-validated target proactively (capability may
+            // also mark additional paths if it writes auxiliary files).
+            selfWrite.markSelfWrite(confinement.normalizedPath);
+
+            let result: AgentCapabilityResult;
+            const execStartedAt = now();
+            try {
+                result = await capability.executeWrite(input, context, hooks);
+            } catch (error) {
+                const durationMs = now() - execStartedAt;
+                const message = error instanceof Error ? error.message : String(error);
+                emit("execute.fail", capability, runId, turnId, {
+                    durationMs,
+                    errorCategory: "fs_error",
+                    extra: {
+                        stage: "executeWrite",
+                        message,
+                        targetCategory: capability.targetCategory,
+                        normalizedPath: confinement.normalizedPath,
+                    },
+                });
+                await runRollback(capability, input, context, runId, turnId);
+                return failure(
+                    capability,
+                    `executeWrite threw: ${message}`,
+                    "The write failed and any partial output was rolled back.",
+                );
+            }
+
+            const durationMs = now() - execStartedAt;
+            if (result.status === "ok") {
+                emit("execute.ok", capability, runId, turnId, {
+                    durationMs,
+                    extra: {
+                        targetCategory: capability.targetCategory,
+                        normalizedPath: confinement.normalizedPath,
+                        totalDurationMs: now() - startedAt,
+                    },
+                });
+                return result;
+            }
+
+            // capability returned non-ok status without throwing — emit fail
+            // but don't auto-rollback (capability may have already cleaned up).
+            emit("execute.fail", capability, runId, turnId, {
+                durationMs,
+                errorCategory: result.status === "unavailable" ? "policy_violation" : "unknown",
+                extra: {
+                    stage: "executeWrite",
+                    capabilityStatus: result.status,
+                    capabilityError: result.error,
+                    targetCategory: capability.targetCategory,
+                    normalizedPath: confinement.normalizedPath,
+                },
+            });
+            await runRollback(capability, input, context, runId, turnId);
+            return result;
+
+            async function runRollback(
+                cap: WriteActionCapability,
+                rawInput: unknown,
+                ctx: AgentCapabilityContext,
+                rid: string,
+                tid: string,
+            ): Promise<void> {
+                if (!cap.rollback) return;
+                const rollbackStart = now();
+                try {
+                    await cap.rollback(rawInput, ctx);
+                    emit("rollback.ok", cap, rid, tid, {
+                        durationMs: now() - rollbackStart,
+                        extra: { targetCategory: cap.targetCategory },
+                    });
+                } catch (error) {
+                    emit("rollback.fail", cap, rid, tid, {
+                        durationMs: now() - rollbackStart,
+                        errorCategory: "fs_error",
+                        extra: {
+                            cascade: true,
+                            message: error instanceof Error ? error.message : String(error),
+                            targetCategory: cap.targetCategory,
+                        },
+                    });
+                }
+            }
+        },
+    };
+}

--- a/src/ai-services/write-action-framework/runtime-integration.ts
+++ b/src/ai-services/write-action-framework/runtime-integration.ts
@@ -113,8 +113,22 @@ export function createSelfWriteRegistry(options: SelfWriteRegistryOptions = {}):
 // ActionExecutor — 4-gate orchestrator
 // ─────────────────────────────────────────────────────────────────────────────
 
-/** Joint FS adapter shape used by Gate 1 + Gate 3. Mirrors `vault.adapter.exists`. */
-export type FsProbe = ConfinementFsProbe & StaleReadProbe;
+/**
+ * Optional `remove` probe used by the framework's create-file rollback safety
+ * net (Fix #4 / SDD §3.3 line 466). Tests usually omit it; production wires
+ * `app.vault.adapter.remove` which already satisfies this signature.
+ */
+export interface FsRemoveProbe {
+    remove(path: string): Promise<void>;
+}
+
+/**
+ * Joint FS adapter shape used by Gate 1 + Gate 3 + create-file auto-rollback.
+ * Mirrors `vault.adapter.{exists,remove}`. `remove` is optional so the
+ * framework degrades gracefully (capability-only rollback) when callers do
+ * not supply it.
+ */
+export type FsProbe = ConfinementFsProbe & StaleReadProbe & Partial<FsRemoveProbe>;
 
 export interface ActionExecutor {
     /**
@@ -192,6 +206,10 @@ export function createActionExecutor(options: ActionExecutorOptions): ActionExec
         };
     }
 
+    function describeError(error: unknown): string {
+        return error instanceof Error ? error.message : String(error);
+    }
+
     return {
         async execute(capability, input, context): Promise<AgentCapabilityResult> {
             const runId = runIdFactory();
@@ -199,42 +217,64 @@ export function createActionExecutor(options: ActionExecutorOptions): ActionExec
             const startedAt = now();
 
             // ────────────────────────────────────────────────────────────────
-            // Gate 0: build preview first (pure per Step 0 contract). This gives
-            // us the target.path string used by Gate 1, without forcing
-            // capabilities to expose a separate getTargetPath() method.
+            // Gate 1 — Target Confinement (Fix #3: runs BEFORE buildPreview)
+            //
+            // We obtain the candidate path from a NEW synchronous + pure
+            // `getTargetPath(input)` API. This ensures untrusted LLM input is
+            // validated against the per-capability allowlist BEFORE any
+            // side-effect-capable code (`buildPreview`) consumes it. The
+            // displayPath in the eventual PreviewSpec is cross-checked
+            // against the path validated here.
             // ────────────────────────────────────────────────────────────────
-            let spec: PreviewSpec;
+            let candidatePath: string;
             try {
-                spec = await capability.buildPreview(input, context);
+                candidatePath = capability.getTargetPath(input);
             } catch (error) {
-                emit("execute.fail", capability, runId, turnId, {
-                    errorCategory: "unknown",
+                emit("gate.target-confinement.reject", capability, runId, turnId, {
+                    errorCategory: "user_aborted",
                     extra: {
-                        stage: "buildPreview",
-                        message: error instanceof Error ? error.message : String(error),
+                        stage: "getTargetPath",
+                        message: describeError(error),
+                        targetCategory: capability.targetCategory,
                     },
                 });
                 return failure(
                     capability,
-                    `buildPreview threw: ${error instanceof Error ? error.message : String(error)}`,
+                    `getTargetPath threw: ${describeError(error)}`,
+                    "The proposed file path was rejected by safety checks.",
                 );
             }
 
-            // ────────────────────────────────────────────────────────────────
-            // Gate 1: target confinement
-            // ────────────────────────────────────────────────────────────────
-            const confinement = await validateTargetConfinement(
-                spec.target.path,
-                capability.targetConfinement,
-                fsProbe,
-            );
+            let confinement: Awaited<ReturnType<typeof validateTargetConfinement>>;
+            try {
+                confinement = await validateTargetConfinement(
+                    candidatePath,
+                    capability.targetConfinement,
+                    fsProbe,
+                );
+            } catch (error) {
+                emit("gate.target-confinement.reject", capability, runId, turnId, {
+                    errorCategory: "fs_error",
+                    extra: {
+                        stage: "validateTargetConfinement",
+                        message: describeError(error),
+                        candidatePath,
+                        targetCategory: capability.targetCategory,
+                    },
+                });
+                return failure(
+                    capability,
+                    `target confinement check failed: ${describeError(error)}`,
+                    "The proposed file path could not be validated.",
+                );
+            }
             if (!confinement.ok) {
                 emit("gate.target-confinement.reject", capability, runId, turnId, {
                     errorCategory: "rejected_at_confinement",
                     extra: {
                         reason: confinement.reason,
                         detail: confinement.detail,
-                        candidatePath: spec.target.path,
+                        candidatePath,
                         targetCategory: capability.targetCategory,
                     },
                 });
@@ -252,17 +292,75 @@ export function createActionExecutor(options: ActionExecutorOptions): ActionExec
             });
 
             // ────────────────────────────────────────────────────────────────
-            // Gate 2: preview-confirmation lifecycle
-            // (snapshot for Gate 3 captured at preview time per SDD §2.3)
+            // Gate 2 — Preview-Confirmation Lifecycle
+            //
+            // buildPreview runs ONLY after the path passed confinement (Fix #3).
+            // The returned spec.target.displayPath must match the confined
+            // path — mismatch is treated as a confinement rejection so a
+            // sneaky capability cannot show a preview for path A and then
+            // write path B.
             // ────────────────────────────────────────────────────────────────
-            const snapshot = fsProbe
-                ? await takeSnapshot(confinement.normalizedPath, fsProbe, now)
-                : {
-                    targetPath: confinement.normalizedPath,
-                    folderExists: true,
-                    targetExists: false,
-                    capturedAt: now(),
-                };
+            let spec: PreviewSpec;
+            try {
+                spec = await capability.buildPreview(input, context);
+            } catch (error) {
+                emit("execute.fail", capability, runId, turnId, {
+                    errorCategory: "user_aborted",
+                    extra: {
+                        stage: "buildPreview",
+                        message: describeError(error),
+                        targetCategory: capability.targetCategory,
+                    },
+                });
+                return failure(
+                    capability,
+                    `buildPreview threw: ${describeError(error)}`,
+                );
+            }
+            if (spec.target.displayPath !== confinement.normalizedPath) {
+                emit("gate.target-confinement.reject", capability, runId, turnId, {
+                    errorCategory: "rejected_at_confinement",
+                    extra: {
+                        reason: "path mismatch between getTargetPath and buildPreview",
+                        getTargetPath: confinement.normalizedPath,
+                        previewDisplayPath: spec.target.displayPath,
+                        targetCategory: capability.targetCategory,
+                    },
+                });
+                return failure(
+                    capability,
+                    "spec.target.displayPath does not match the confined path",
+                    "The proposed file path was rejected by safety checks.",
+                );
+            }
+
+            // Snapshot for Gate 3 captured at preview time per SDD §2.3.
+            // `takeSnapshot` only runs when fsProbe is supplied; wrap in
+            // try/catch (Fix #5) so a probe fault never escapes as an
+            // unhandled rejection.
+            let snapshot: ReturnType<typeof buildEmptySnapshot>;
+            if (fsProbe) {
+                try {
+                    snapshot = await takeSnapshot(confinement.normalizedPath, fsProbe, now);
+                } catch (error) {
+                    emit("gate.target-confinement.reject", capability, runId, turnId, {
+                        errorCategory: "fs_error",
+                        extra: {
+                            stage: "takeSnapshot",
+                            message: describeError(error),
+                            normalizedPath: confinement.normalizedPath,
+                            targetCategory: capability.targetCategory,
+                        },
+                    });
+                    return failure(
+                        capability,
+                        `takeSnapshot failed: ${describeError(error)}`,
+                        "The file state could not be sampled before preview.",
+                    );
+                }
+            } else {
+                snapshot = buildEmptySnapshot(confinement.normalizedPath, now());
+            }
             emit("gate.preview.shown", capability, runId, turnId, {
                 extra: {
                     targetCategory: capability.targetCategory,
@@ -270,9 +368,29 @@ export function createActionExecutor(options: ActionExecutorOptions): ActionExec
                     snapshotAt: snapshot.capturedAt,
                 },
             });
-            const { outcome, renderWarnings } = await previewRenderer.show(spec, {
-                signal: context.signal,
-            });
+            let outcome: Awaited<ReturnType<typeof previewRenderer.show>>["outcome"];
+            let renderWarnings: string[] | undefined;
+            try {
+                const showResult = await previewRenderer.show(spec, {
+                    signal: context.signal,
+                });
+                outcome = showResult.outcome;
+                renderWarnings = showResult.renderWarnings;
+            } catch (error) {
+                emit("gate.confirmation.received", capability, runId, turnId, {
+                    errorCategory: "preview_render_failed",
+                    extra: {
+                        outcome: "aborted",
+                        renderWarnings: [`preview renderer threw: ${describeError(error)}`],
+                        targetCategory: capability.targetCategory,
+                    },
+                });
+                return failure(
+                    capability,
+                    `preview render failed: ${describeError(error)}`,
+                    "The preview could not be displayed; the action was cancelled.",
+                );
+            }
             emit("gate.confirmation.received", capability, runId, turnId, {
                 extra: {
                     outcome,
@@ -289,13 +407,32 @@ export function createActionExecutor(options: ActionExecutorOptions): ActionExec
             }
 
             // ────────────────────────────────────────────────────────────────
-            // Gate 3: stale re-read (mode A)
+            // Gate 3 — Stale Re-read (mode A)
             // ────────────────────────────────────────────────────────────────
             if (fsProbe) {
-                const stale = await checkStaleReread(snapshot, fsProbe, now);
+                let stale: Awaited<ReturnType<typeof checkStaleReread>>;
+                try {
+                    stale = await checkStaleReread(snapshot, fsProbe, now);
+                } catch (error) {
+                    emit("gate.stale-reread.drift", capability, runId, turnId, {
+                        errorCategory: "fs_error",
+                        extra: {
+                            stage: "checkStaleReread",
+                            message: describeError(error),
+                            normalizedPath: confinement.normalizedPath,
+                            targetCategory: capability.targetCategory,
+                            snapshotAt: snapshot.capturedAt,
+                        },
+                    });
+                    return failure(
+                        capability,
+                        `stale-reread probe failed: ${describeError(error)}`,
+                        "The file state could not be re-validated before write.",
+                    );
+                }
                 if (stale.stale) {
                     emit("gate.stale-reread.drift", capability, runId, turnId, {
-                        errorCategory: "stale_drift",
+                        errorCategory: "stale_target",
                         extra: {
                             drift: stale.drift,
                             targetCategory: capability.targetCategory,
@@ -341,11 +478,12 @@ export function createActionExecutor(options: ActionExecutorOptions): ActionExec
 
             let result: AgentCapabilityResult;
             const execStartedAt = now();
+            let executeAttempted = true;
             try {
                 result = await capability.executeWrite(input, context, hooks);
             } catch (error) {
                 const durationMs = now() - execStartedAt;
-                const message = error instanceof Error ? error.message : String(error);
+                const message = describeError(error);
                 emit("execute.fail", capability, runId, turnId, {
                     durationMs,
                     errorCategory: "fs_error",
@@ -356,7 +494,15 @@ export function createActionExecutor(options: ActionExecutorOptions): ActionExec
                         normalizedPath: confinement.normalizedPath,
                     },
                 });
-                await runRollback(capability, input, context, runId, turnId);
+                await runRollback(
+                    capability,
+                    input,
+                    context,
+                    runId,
+                    turnId,
+                    confinement.normalizedPath,
+                    executeAttempted,
+                );
                 return failure(
                     capability,
                     `executeWrite threw: ${message}`,
@@ -374,14 +520,23 @@ export function createActionExecutor(options: ActionExecutorOptions): ActionExec
                         totalDurationMs: now() - startedAt,
                     },
                 });
+                // Fix #7: refresh the self-write TTL after a slow vault IO
+                // path. The capability's own markSelfWrite (called inside
+                // executeWrite) and our pre-execute mark may have aged past
+                // the 5s window if executeWrite took a long time; this
+                // belt-and-suspenders refresh keeps the modify listener
+                // suppression honest on the success path.
+                selfWrite.markSelfWrite(confinement.normalizedPath);
                 return result;
             }
 
             // capability returned non-ok status without throwing — emit fail
-            // but don't auto-rollback (capability may have already cleaned up).
+            // with category mapped to capability status. Auto-rollback still
+            // runs so create-file partial writes don't linger.
             emit("execute.fail", capability, runId, turnId, {
                 durationMs,
-                errorCategory: result.status === "unavailable" ? "policy_violation" : "unknown",
+                errorCategory:
+                    result.status === "unavailable" ? "permission_denied" : "fs_error",
                 extra: {
                     stage: "executeWrite",
                     capabilityStatus: result.status,
@@ -390,36 +545,117 @@ export function createActionExecutor(options: ActionExecutorOptions): ActionExec
                     normalizedPath: confinement.normalizedPath,
                 },
             });
-            await runRollback(capability, input, context, runId, turnId);
+            await runRollback(
+                capability,
+                input,
+                context,
+                runId,
+                turnId,
+                confinement.normalizedPath,
+                executeAttempted,
+            );
             return result;
 
+            /**
+             * Run capability rollback (when declared) followed by the
+             * framework's create-file safety net (Fix #4). Either step may
+             * run independently:
+             *
+             *   - `cap.rollback` is awaited first when declared.
+             *   - The framework `fsProbe.remove(target)` then runs when the
+             *     family is `create-file`, a probe is wired, and executeWrite
+             *     was attempted. This honors SDD §3.3 line 466: the framework
+             *     auto-removes the partial file even when the capability did
+             *     not implement rollback.
+             *
+             * Both surfaces emit a separate `rollback.ok` / `rollback.fail`
+             * pair so the developer can tell which layer cleaned up.
+             */
             async function runRollback(
                 cap: WriteActionCapability,
                 rawInput: unknown,
                 ctx: AgentCapabilityContext,
                 rid: string,
                 tid: string,
+                normalizedPath: string,
+                writeAttempted: boolean,
             ): Promise<void> {
-                if (!cap.rollback) return;
-                const rollbackStart = now();
-                try {
-                    await cap.rollback(rawInput, ctx);
-                    emit("rollback.ok", cap, rid, tid, {
-                        durationMs: now() - rollbackStart,
-                        extra: { targetCategory: cap.targetCategory },
-                    });
-                } catch (error) {
-                    emit("rollback.fail", cap, rid, tid, {
-                        durationMs: now() - rollbackStart,
-                        errorCategory: "fs_error",
-                        extra: {
-                            cascade: true,
-                            message: error instanceof Error ? error.message : String(error),
-                            targetCategory: cap.targetCategory,
-                        },
-                    });
+                if (cap.rollback) {
+                    const rollbackStart = now();
+                    try {
+                        await cap.rollback(rawInput, ctx);
+                        emit("rollback.ok", cap, rid, tid, {
+                            durationMs: now() - rollbackStart,
+                            extra: {
+                                layer: "capability",
+                                targetCategory: cap.targetCategory,
+                            },
+                        });
+                    } catch (error) {
+                        emit("rollback.fail", cap, rid, tid, {
+                            durationMs: now() - rollbackStart,
+                            errorCategory: "fs_error",
+                            extra: {
+                                layer: "capability",
+                                cascade: true,
+                                message: describeError(error),
+                                targetCategory: cap.targetCategory,
+                            },
+                        });
+                    }
+                }
+                // Framework safety net for create-file (SDD §3.3 line 466).
+                if (
+                    cap.actionFamily === "create-file"
+                    && writeAttempted
+                    && fsProbe?.remove
+                ) {
+                    const removeStart = now();
+                    try {
+                        await fsProbe.remove(normalizedPath);
+                        emit("rollback.ok", cap, rid, tid, {
+                            durationMs: now() - removeStart,
+                            extra: {
+                                layer: "framework",
+                                cascade: Boolean(cap.rollback),
+                                normalizedPath,
+                                targetCategory: cap.targetCategory,
+                            },
+                        });
+                    } catch (error) {
+                        emit("rollback.fail", cap, rid, tid, {
+                            durationMs: now() - removeStart,
+                            errorCategory: "fs_error",
+                            extra: {
+                                layer: "framework",
+                                cascade: Boolean(cap.rollback),
+                                normalizedPath,
+                                message: describeError(error),
+                                targetCategory: cap.targetCategory,
+                            },
+                        });
+                    }
                 }
             }
         },
+    };
+}
+
+/**
+ * Build the placeholder snapshot used when no FS probe is wired. Mirrors the
+ * old inline literal but extracted for typing (`takeSnapshot` returns
+ * `Promise<TargetSnapshot>` which is the same shape).
+ */
+function buildEmptySnapshot(targetPath: string, capturedAt: number): {
+    targetPath: string;
+    folderExists: boolean;
+    targetExists: boolean;
+    capturedAt: number;
+} {
+    return {
+        targetPath,
+        folderExists: true,
+        targetExists: false,
+        capturedAt,
     };
 }

--- a/src/ai-services/write-action-framework/stale-reread.spec.ts
+++ b/src/ai-services/write-action-framework/stale-reread.spec.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it, jest } from "@jest/globals";
+
+import {
+    checkStaleReread,
+    takeSnapshot,
+    type StaleReadProbe,
+} from "./stale-reread";
+
+function probe(map: Record<string, boolean>): StaleReadProbe {
+    return {
+        exists: jest.fn(async (path: string) => map[path] ?? false) as StaleReadProbe["exists"],
+    };
+}
+
+describe("takeSnapshot (framework SDD §2.3 mode A)", () => {
+    it("captures folderExists + targetExists at vault path", async () => {
+        const fs = probe({ ".pagelet": true, ".pagelet/foo.md": false });
+        const snap = await takeSnapshot(".pagelet/foo.md", fs, () => 1000);
+        expect(snap).toEqual({
+            targetPath: ".pagelet/foo.md",
+            folderExists: true,
+            targetExists: false,
+            capturedAt: 1000,
+        });
+    });
+
+    it("reports folderExists=true implicitly when target is at vault root", async () => {
+        const fs = probe({ "root.md": false });
+        const snap = await takeSnapshot("root.md", fs);
+        expect(snap.folderExists).toBe(true);
+        expect(snap.targetExists).toBe(false);
+    });
+
+    it("captures targetExists=true when target already exists", async () => {
+        const fs = probe({ ".pagelet": true, ".pagelet/foo.md": true });
+        const snap = await takeSnapshot(".pagelet/foo.md", fs);
+        expect(snap.folderExists).toBe(true);
+        expect(snap.targetExists).toBe(true);
+    });
+});
+
+describe("checkStaleReread (drift detection)", () => {
+    it("returns stale=false when state is unchanged", async () => {
+        const fs = probe({ ".pagelet": true, ".pagelet/foo.md": false });
+        const snap = await takeSnapshot(".pagelet/foo.md", fs);
+        const result = await checkStaleReread(snap, fs, () => 2000);
+        expect(result).toEqual({ stale: false, checkedAt: 2000 });
+    });
+
+    it("detects targetAppeared when another actor created the file after preview", async () => {
+        const fsBefore = probe({ ".pagelet": true, ".pagelet/foo.md": false });
+        const snap = await takeSnapshot(".pagelet/foo.md", fsBefore);
+        const fsAfter = probe({ ".pagelet": true, ".pagelet/foo.md": true });
+        const result = await checkStaleReread(snap, fsAfter);
+        expect(result.stale).toBe(true);
+        if (result.stale) expect(result.drift).toMatchObject({ targetAppeared: true });
+    });
+
+    it("detects folderDisappeared when the parent folder is removed after preview", async () => {
+        const fsBefore = probe({ ".pagelet": true, ".pagelet/foo.md": false });
+        const snap = await takeSnapshot(".pagelet/foo.md", fsBefore);
+        const fsAfter = probe({ ".pagelet": false, ".pagelet/foo.md": false });
+        const result = await checkStaleReread(snap, fsAfter);
+        expect(result.stale).toBe(true);
+        if (result.stale) expect(result.drift).toMatchObject({ folderDisappeared: true });
+    });
+
+    it("detects targetDisappeared when a snapshot-time-existing target is removed", async () => {
+        // edge case: snapshot saw target as existing (collision would have rejected
+        // at Gate 1 in real flow, but verify drift detection is symmetric)
+        const fsBefore = probe({ ".pagelet": true, ".pagelet/foo.md": true });
+        const snap = await takeSnapshot(".pagelet/foo.md", fsBefore);
+        const fsAfter = probe({ ".pagelet": true, ".pagelet/foo.md": false });
+        const result = await checkStaleReread(snap, fsAfter);
+        expect(result.stale).toBe(true);
+        if (result.stale) expect(result.drift).toMatchObject({ targetDisappeared: true });
+    });
+
+    it("detects folderReappeared (defensive drift signal)", async () => {
+        const fsBefore = probe({ ".pagelet": false, ".pagelet/foo.md": false });
+        const snap = await takeSnapshot(".pagelet/foo.md", fsBefore);
+        const fsAfter = probe({ ".pagelet": true, ".pagelet/foo.md": false });
+        const result = await checkStaleReread(snap, fsAfter);
+        expect(result.stale).toBe(true);
+        if (result.stale) expect(result.drift).toMatchObject({ folderReappeared: true });
+    });
+
+    it("reports multiple drift flags together (folderDisappeared + targetAppeared)", async () => {
+        const fsBefore = probe({ ".pagelet": true, ".pagelet/foo.md": false });
+        const snap = await takeSnapshot(".pagelet/foo.md", fsBefore);
+        const fsAfter = probe({ ".pagelet": false, ".pagelet/foo.md": true });
+        const result = await checkStaleReread(snap, fsAfter);
+        expect(result.stale).toBe(true);
+        if (result.stale) {
+            expect(result.drift).toMatchObject({
+                folderDisappeared: true,
+                targetAppeared: true,
+            });
+        }
+    });
+});

--- a/src/ai-services/write-action-framework/stale-reread.ts
+++ b/src/ai-services/write-action-framework/stale-reread.ts
@@ -1,0 +1,87 @@
+/**
+ * Stale Re-read Module (Gate 3) — framework SDD §2.3, mode A only.
+ *
+ * Detects time-of-check / time-of-use drift between when the preview was shown
+ * to the user and when the write actually executes. v1 covers only "mode A":
+ * target snapshot (folder existence + target existence). Mode B (source content
+ * hash for append/replace families) is deferred to Operations Agent mode — see
+ * framework SDD §10 upgrade trigger.
+ *
+ * Lifecycle:
+ *   1. After Gate 1 passes, framework calls `takeSnapshot(normalizedPath, fs)`.
+ *   2. Modal renders; user confirms.
+ *   3. Before calling `capability.executeWrite`, framework calls
+ *      `checkStaleReread(snapshot, fs)`.
+ *   4. Any drift (folder disappeared, target appeared, or — defensive — folder
+ *      reappeared after being absent) returns `{ stale: true, drift: {...} }`
+ *      and the runtime emits `gate.stale-reread.drift`.
+ */
+
+import type { TargetSnapshot } from "./types";
+
+export interface StaleReadProbe {
+    exists(path: string): Promise<boolean>;
+}
+
+export interface StaleDriftDetail {
+    folderDisappeared?: boolean;
+    folderReappeared?: boolean;
+    targetAppeared?: boolean;
+    targetDisappeared?: boolean;
+}
+
+export type StaleReadResult =
+    | { stale: false; checkedAt: number }
+    | { stale: true; drift: StaleDriftDetail; checkedAt: number };
+
+/**
+ * Capture folder/target existence at the moment a preview is shown.
+ * Folder is derived as the parent of `targetPath` (POSIX-style); a target at
+ * the vault root reports `folderExists=true` (root always exists).
+ */
+export async function takeSnapshot(
+    targetPath: string,
+    fs: StaleReadProbe,
+    now: () => number = Date.now,
+): Promise<TargetSnapshot> {
+    const lastSlash = targetPath.lastIndexOf("/");
+    const folder = lastSlash > 0 ? targetPath.substring(0, lastSlash) : "";
+    const folderExists = folder === "" ? true : await fs.exists(folder);
+    const targetExists = await fs.exists(targetPath);
+    return {
+        targetPath,
+        folderExists,
+        targetExists,
+        capturedAt: now(),
+    };
+}
+
+/**
+ * Re-read folder/target existence and compare against the snapshot. **Any**
+ * difference between snapshot and current state counts as drift, even
+ * superficially "harmless" ones (e.g., a target that briefly appeared and
+ * disappeared again is not observable here, but a folder that vanished and
+ * came back IS reported because `folderReappeared` could mask a structural
+ * change underneath).
+ */
+export async function checkStaleReread(
+    snapshot: TargetSnapshot,
+    fs: StaleReadProbe,
+    now: () => number = Date.now,
+): Promise<StaleReadResult> {
+    const lastSlash = snapshot.targetPath.lastIndexOf("/");
+    const folder = lastSlash > 0 ? snapshot.targetPath.substring(0, lastSlash) : "";
+    const folderNow = folder === "" ? true : await fs.exists(folder);
+    const targetNow = await fs.exists(snapshot.targetPath);
+
+    const drift: StaleDriftDetail = {};
+    if (snapshot.folderExists && !folderNow) drift.folderDisappeared = true;
+    if (!snapshot.folderExists && folderNow) drift.folderReappeared = true;
+    if (!snapshot.targetExists && targetNow) drift.targetAppeared = true;
+    if (snapshot.targetExists && !targetNow) drift.targetDisappeared = true;
+
+    if (Object.keys(drift).length === 0) {
+        return { stale: false, checkedAt: now() };
+    }
+    return { stale: true, drift, checkedAt: now() };
+}

--- a/src/ai-services/write-action-framework/target-confinement.spec.ts
+++ b/src/ai-services/write-action-framework/target-confinement.spec.ts
@@ -1,0 +1,202 @@
+import { describe, expect, it, jest } from "@jest/globals";
+
+import {
+    DEFAULT_MAX_PATH_LENGTH,
+    validateTargetConfinement,
+    validateTargetConfinementSync,
+    type ConfinementFsProbe,
+} from "./target-confinement";
+import type { ConfinementConfig } from "./types";
+
+const baseConfig: ConfinementConfig = {
+    allowedRoots: [".pagelet/"],
+    allowedExtensions: [".md"],
+    maxPathLength: 200,
+};
+
+describe("validateTargetConfinementSync (framework SDD §2.2)", () => {
+    it("accepts a clean vault-relative .md inside .pagelet/", () => {
+        const result = validateTargetConfinementSync(".pagelet/2026-06-02-meeting.md", baseConfig);
+        expect(result).toEqual({ ok: true, normalizedPath: ".pagelet/2026-06-02-meeting.md" });
+    });
+
+    it("rejects empty_path for empty string", () => {
+        expect(validateTargetConfinementSync("", baseConfig)).toMatchObject({
+            ok: false,
+            reason: "empty_path",
+        });
+    });
+
+    it("rejects empty_path for whitespace-only string", () => {
+        expect(validateTargetConfinementSync("   ", baseConfig)).toMatchObject({
+            ok: false,
+            reason: "empty_path",
+        });
+    });
+
+    it("rejects control_char when path contains NUL/0x01", () => {
+        const withNul = ".pagelet/foo\x00bar.md";
+        expect(validateTargetConfinementSync(withNul, baseConfig)).toMatchObject({
+            ok: false,
+            reason: "control_char",
+        });
+    });
+
+    it("rejects absolute_path for leading slash", () => {
+        expect(validateTargetConfinementSync("/etc/passwd", baseConfig)).toMatchObject({
+            ok: false,
+            reason: "absolute_path",
+        });
+    });
+
+    it("rejects drive_letter for Windows-style C:/...", () => {
+        expect(validateTargetConfinementSync("C:/Users/x.md", baseConfig)).toMatchObject({
+            ok: false,
+            reason: "drive_letter",
+        });
+        // lowercase drive too
+        expect(validateTargetConfinementSync("c:\\foo.md", baseConfig)).toMatchObject({
+            ok: false,
+            reason: "drive_letter",
+        });
+    });
+
+    it("rejects parent_traversal for embedded .. segment", () => {
+        expect(validateTargetConfinementSync(".pagelet/../config.json", baseConfig)).toMatchObject({
+            ok: false,
+            reason: "parent_traversal",
+        });
+        expect(validateTargetConfinementSync("../escape.md", baseConfig)).toMatchObject({
+            ok: false,
+            reason: "parent_traversal",
+        });
+    });
+
+    it("rejects path_too_long when normalized path exceeds maxPathLength", () => {
+        const longName = "a".repeat(300);
+        const result = validateTargetConfinementSync(`.pagelet/${longName}.md`, baseConfig);
+        expect(result).toMatchObject({ ok: false, reason: "path_too_long" });
+    });
+
+    it("uses DEFAULT_MAX_PATH_LENGTH when maxPathLength omitted", () => {
+        const cfg: ConfinementConfig = { allowedRoots: [".pagelet/"], allowedExtensions: [".md"] };
+        const longName = "a".repeat(DEFAULT_MAX_PATH_LENGTH);
+        const result = validateTargetConfinementSync(`.pagelet/${longName}.md`, cfg);
+        expect(result.ok).toBe(false);
+        if (!result.ok) expect(result.reason).toBe("path_too_long");
+    });
+
+    it("rejects outside_allowlist for paths outside allowedRoots", () => {
+        expect(validateTargetConfinementSync("other-folder/foo.md", baseConfig)).toMatchObject({
+            ok: false,
+            reason: "outside_allowlist",
+        });
+    });
+
+    it("rejects outside_allowlist when allowedRoots is empty", () => {
+        const cfg: ConfinementConfig = { allowedRoots: [], allowedExtensions: [".md"] };
+        expect(validateTargetConfinementSync(".pagelet/foo.md", cfg)).toMatchObject({
+            ok: false,
+            reason: "outside_allowlist",
+        });
+    });
+
+    it("rejects bad_extension for wrong extension", () => {
+        expect(validateTargetConfinementSync(".pagelet/foo.txt", baseConfig)).toMatchObject({
+            ok: false,
+            reason: "bad_extension",
+        });
+    });
+
+    it("rejects bad_extension when allowedExtensions is empty", () => {
+        const cfg: ConfinementConfig = { allowedRoots: [".pagelet/"], allowedExtensions: [] };
+        expect(validateTargetConfinementSync(".pagelet/foo.md", cfg)).toMatchObject({
+            ok: false,
+            reason: "bad_extension",
+        });
+    });
+
+    it("rejects custom_pattern_rejected when a caller-supplied rejectPattern matches", () => {
+        const cfg: ConfinementConfig = {
+            ...baseConfig,
+            rejectPatterns: [/secret/i],
+        };
+        expect(validateTargetConfinementSync(".pagelet/my-secret.md", cfg)).toMatchObject({
+            ok: false,
+            reason: "custom_pattern_rejected",
+        });
+    });
+
+    it("normalizes leading './' and collapses duplicate slashes", () => {
+        const result = validateTargetConfinementSync("./.pagelet//deep///file.md", baseConfig);
+        expect(result).toEqual({ ok: true, normalizedPath: ".pagelet/deep/file.md" });
+    });
+
+    it("normalizes backslashes to forward slashes (still validated against allowlist)", () => {
+        const result = validateTargetConfinementSync(".pagelet\\nested\\file.md", baseConfig);
+        expect(result).toEqual({ ok: true, normalizedPath: ".pagelet/nested/file.md" });
+    });
+
+    it("accepts a multi-root allowlist", () => {
+        const cfg: ConfinementConfig = {
+            allowedRoots: [".pagelet/", ".pagelet-reviews/"],
+            allowedExtensions: [".md"],
+        };
+        expect(validateTargetConfinementSync(".pagelet-reviews/note.md", cfg)).toEqual({
+            ok: true,
+            normalizedPath: ".pagelet-reviews/note.md",
+        });
+    });
+});
+
+describe("validateTargetConfinement (async with FS probe)", () => {
+    function probe(map: Record<string, boolean>): ConfinementFsProbe {
+        return {
+            exists: jest.fn(async (path: string) => map[path] ?? false) as ConfinementFsProbe["exists"],
+        };
+    }
+
+    it("returns sync result when no FS probe supplied", async () => {
+        const result = await validateTargetConfinement(".pagelet/foo.md", baseConfig);
+        expect(result).toEqual({ ok: true, normalizedPath: ".pagelet/foo.md" });
+    });
+
+    it("rejects folder_missing when parent folder absent", async () => {
+        const fs = probe({});
+        const result = await validateTargetConfinement(".pagelet/sub/foo.md", baseConfig, fs);
+        expect(result).toMatchObject({ ok: false, reason: "folder_missing", detail: ".pagelet/sub" });
+    });
+
+    it("rejects name_collision when target already exists", async () => {
+        const fs = probe({ ".pagelet": true, ".pagelet/foo.md": true });
+        const result = await validateTargetConfinement(".pagelet/foo.md", baseConfig, fs);
+        expect(result).toMatchObject({ ok: false, reason: "name_collision", detail: ".pagelet/foo.md" });
+    });
+
+    it("returns ok when folder exists and target does not collide", async () => {
+        const fs = probe({ ".pagelet": true });
+        const result = await validateTargetConfinement(".pagelet/foo.md", baseConfig, fs);
+        expect(result).toEqual({ ok: true, normalizedPath: ".pagelet/foo.md" });
+    });
+
+    it("skips folder probe when path is at vault root (no slash)", async () => {
+        // edge: a path with no slash means folder=""; probe should not be called for folder
+        const cfg: ConfinementConfig = { allowedRoots: ["./"], allowedExtensions: [".md"] };
+        const fs = probe({});
+        // candidate has root "./" → normalized "foo.md" → folder=""
+        const result = await validateTargetConfinement("./foo.md", cfg, fs);
+        // bypass folder check; collision probe runs (returns false → ok)
+        // outside_allowlist may apply since "foo.md" doesn't start with "./" once normalized
+        // — so this should reject as outside_allowlist (the test ensures we hit that branch
+        // rather than the folder branch).
+        expect(result.ok).toBe(false);
+        if (!result.ok) expect(result.reason).toBe("outside_allowlist");
+    });
+
+    it("short-circuits FS probe when sync validation fails", async () => {
+        const fs = probe({});
+        const result = await validateTargetConfinement("/etc/passwd", baseConfig, fs);
+        expect(result).toMatchObject({ ok: false, reason: "absolute_path" });
+        expect((fs.exists as jest.Mock)).not.toHaveBeenCalled();
+    });
+});

--- a/src/ai-services/write-action-framework/target-confinement.ts
+++ b/src/ai-services/write-action-framework/target-confinement.ts
@@ -1,0 +1,181 @@
+/**
+ * Target Confinement Module (Gate 1) — framework SDD §2.2.
+ *
+ * Deterministic, fail-closed path validation for write actions. Runs **before**
+ * preview rendering so LLM-produced paths that escape allowlist never reach the
+ * user-facing modal.
+ *
+ * Two-stage API:
+ *   - `validateTargetConfinementSync(candidate, config)` — pure string-only checks
+ *     (normalize / allowlist / parent traversal / control chars / extension / length).
+ *     Suitable for unit tests with no FS dependency.
+ *   - `validateTargetConfinement(candidate, config, fs?)` — async wrapper that
+ *     additionally probes folder existence and target collision via the supplied
+ *     `ConfinementFsProbe`. Used by the runtime ActionExecutor.
+ *
+ * Reject reasons are categorized (not a single generic "invalid") so the runtime
+ * can emit precise `gate.target-confinement.reject` debug events for triage.
+ */
+
+import type { ConfinementConfig } from "./types";
+
+export type ConfinementRejectReason =
+    | "empty_path"
+    | "absolute_path"
+    | "drive_letter"
+    | "parent_traversal"
+    | "control_char"
+    | "outside_allowlist"
+    | "bad_extension"
+    | "path_too_long"
+    | "custom_pattern_rejected"
+    | "name_collision"
+    | "folder_missing";
+
+export type ConfinementResult =
+    | { ok: true; normalizedPath: string }
+    | { ok: false; reason: ConfinementRejectReason; detail?: string };
+
+/**
+ * Filesystem probe used by the async {@link validateTargetConfinement} wrapper
+ * to check folder existence and target collision. Adapter shape is intentionally
+ * narrow so callers can pass either Obsidian's `vault.adapter` (which already
+ * implements `exists`) or a mock in tests.
+ */
+export interface ConfinementFsProbe {
+    exists(path: string): Promise<boolean>;
+}
+
+/** Framework default max path length (framework SDD §2.2). */
+export const DEFAULT_MAX_PATH_LENGTH = 200;
+
+/**
+ * Pure sync validation. Categorized checks run in fixed order so the first
+ * concrete reason wins (e.g., an absolute path containing control chars
+ * reports `absolute_path` first).
+ *
+ * Order: empty → control_char → absolute → drive_letter → normalize →
+ *        parent_traversal → length → allowlist → extension → custom rejectPatterns.
+ */
+export function validateTargetConfinementSync(
+    candidate: string,
+    config: ConfinementConfig,
+): ConfinementResult {
+    if (candidate === null || candidate === undefined) {
+        return { ok: false, reason: "empty_path", detail: "candidate is null/undefined" };
+    }
+    if (typeof candidate !== "string" || candidate.length === 0 || candidate.trim() === "") {
+        return { ok: false, reason: "empty_path" };
+    }
+
+    // 1. Control characters (NUL through 0x1F). Detect on raw input before any
+    // normalization to catch payloads that try to smuggle bytes past trim/replace.
+    if (/[\x00-\x1f]/.test(candidate)) {
+        return { ok: false, reason: "control_char" };
+    }
+
+    // 2. Absolute path (POSIX-style leading "/").
+    if (candidate.startsWith("/")) {
+        return { ok: false, reason: "absolute_path" };
+    }
+
+    // 3. Windows drive letter (e.g., "C:/...", "c:\..."). Catch before normalize.
+    if (/^[a-zA-Z]:/.test(candidate)) {
+        return { ok: false, reason: "drive_letter" };
+    }
+
+    // 4. Normalize: convert backslashes to forward slashes (Obsidian uses POSIX
+    // separators), strip leading "./", collapse repeated "//".
+    let normalized = candidate.replace(/\\/g, "/").replace(/^\.\//, "").replace(/\/+/g, "/");
+    // Strip a trailing slash so extension check has a real filename to inspect.
+    if (normalized.endsWith("/") && normalized.length > 1) {
+        normalized = normalized.slice(0, -1);
+    }
+
+    // 5. Parent traversal: any segment equal to ".." (covers "../x", "a/../b", "a/..").
+    const segments = normalized.split("/");
+    if (segments.some((segment) => segment === "..")) {
+        return { ok: false, reason: "parent_traversal" };
+    }
+
+    // 6. Length cap.
+    const maxLength = config.maxPathLength ?? DEFAULT_MAX_PATH_LENGTH;
+    if (normalized.length > maxLength) {
+        return { ok: false, reason: "path_too_long", detail: `${normalized.length} > ${maxLength}` };
+    }
+
+    // 7. Allowlist: normalizedPath must start with one of the allowed roots.
+    if (!config.allowedRoots || config.allowedRoots.length === 0) {
+        return { ok: false, reason: "outside_allowlist", detail: "no allowedRoots configured" };
+    }
+    const insideAllowlist = config.allowedRoots.some((root) => {
+        const rootWithSlash = root.endsWith("/") ? root : `${root}/`;
+        return normalized === root || normalized.startsWith(rootWithSlash);
+    });
+    if (!insideAllowlist) {
+        return { ok: false, reason: "outside_allowlist" };
+    }
+
+    // 8. Extension.
+    const lastDot = normalized.lastIndexOf(".");
+    const lastSlash = normalized.lastIndexOf("/");
+    const ext = lastDot > lastSlash ? normalized.substring(lastDot) : "";
+    if (!config.allowedExtensions || config.allowedExtensions.length === 0) {
+        return { ok: false, reason: "bad_extension", detail: "no allowedExtensions configured" };
+    }
+    if (!config.allowedExtensions.includes(ext)) {
+        return { ok: false, reason: "bad_extension", detail: `got "${ext}"` };
+    }
+
+    // 9. Custom reject patterns (caller extensibility; runs after built-in checks).
+    if (config.rejectPatterns) {
+        for (const pattern of config.rejectPatterns) {
+            if (pattern.test(normalized) || pattern.test(candidate)) {
+                return {
+                    ok: false,
+                    reason: "custom_pattern_rejected",
+                    detail: `matched ${pattern.toString()}`,
+                };
+            }
+        }
+    }
+
+    return { ok: true, normalizedPath: normalized };
+}
+
+/**
+ * Async validation wrapper. Runs the sync checks first; if those pass and
+ * a `fs` probe is supplied, additionally checks:
+ *   - folder existence (parent of normalizedPath)
+ *   - target collision (normalizedPath itself; v1 create-file refuses overwrite)
+ *
+ * When `fs` is omitted (e.g., pure unit tests), behaves identically to the
+ * sync variant.
+ */
+export async function validateTargetConfinement(
+    candidate: string,
+    config: ConfinementConfig,
+    fs?: ConfinementFsProbe,
+): Promise<ConfinementResult> {
+    const syncResult = validateTargetConfinementSync(candidate, config);
+    if (!syncResult.ok || !fs) {
+        return syncResult;
+    }
+    const normalized = syncResult.normalizedPath;
+    const lastSlash = normalized.lastIndexOf("/");
+    const folder = lastSlash > 0 ? normalized.substring(0, lastSlash) : "";
+
+    // Probe folder first so a missing parent is reported distinctly from collision.
+    if (folder !== "") {
+        const folderExists = await fs.exists(folder);
+        if (!folderExists) {
+            return { ok: false, reason: "folder_missing", detail: folder };
+        }
+    }
+
+    const targetExists = await fs.exists(normalized);
+    if (targetExists) {
+        return { ok: false, reason: "name_collision", detail: normalized };
+    }
+    return syncResult;
+}

--- a/src/ai-services/write-action-framework/types.ts
+++ b/src/ai-services/write-action-framework/types.ts
@@ -44,6 +44,37 @@ export interface WriteActionExecuteHooks {
 }
 
 /**
+ * Per-capability target confinement rule (framework SDD §2.2 / §3.1).
+ *
+ * Declared on each WriteActionCapability so Gate 1 can validate target paths
+ * before buildPreview/executeWrite. ConfinementConfig is the runtime-facing alias.
+ */
+export interface ConfinementConfig {
+    /** Allowed vault-relative path prefixes (e.g., [".pagelet/"]). Required, non-empty. */
+    allowedRoots: string[];
+    /** Allowed file extensions (e.g., [".md"]). Required, non-empty. */
+    allowedExtensions: string[];
+    /** Max normalized path length. Default 200 (framework SDD §2.2). */
+    maxPathLength?: number;
+    /** Optional caller-supplied additional reject patterns; runs after built-in categorized checks. */
+    rejectPatterns?: readonly RegExp[];
+}
+
+/**
+ * Stale-reread target snapshot (framework SDD §2.3 mode A).
+ *
+ * Captured at Gate 2 (preview shown) and re-validated at Gate 3 (before execute).
+ * Drift on folderExists / targetExists → reject + emit `gate.stale-reread.drift`.
+ */
+export interface TargetSnapshot {
+    targetPath: string;
+    folderExists: boolean;
+    targetExists: boolean;
+    /** Date.now() at capture time. Useful for debug emit aging analysis. */
+    capturedAt: number;
+}
+
+/**
  * Write Action Capability — MUST be invoked via framework ActionExecutor.
  *
  * Framework 4-gate 流程：
@@ -59,10 +90,14 @@ export interface WriteActionCapability extends AgentCapability {
     actionFamily: WriteActionFamily;
     /** Debug emit 分类标签（如 "pagelet-review-note"）。用于 debug observer 聚合分析 */
     targetCategory: string;
+    /** Per-capability path allowlist + extension + rejectPatterns (framework SDD §2.2). */
+    targetConfinement: ConfinementConfig;
 
     /**
      * 由 framework Gate 2 (preview-confirmation lifecycle) 调用。
      * 返回 5 区块 PreviewSpec 供 modal 渲染。MUST 是纯函数（无副作用）。
+     *
+     * 同时被 Gate 1 用来提取 target 候选路径（spec.target.path）。
      */
     buildPreview(input: unknown, context: AgentCapabilityContext): Promise<PreviewSpec>;
 

--- a/src/ai-services/write-action-framework/types.ts
+++ b/src/ai-services/write-action-framework/types.ts
@@ -13,24 +13,48 @@ import type {
 export type WriteActionFamily = "create-file";
 
 /**
- * 5 区块 preview spec (framework SDD §2.1 + §7.1)。Preview modal 渲染 + LLM 不可绕开。
+ * Typed preview spec (framework SDD §2.1)。Preview modal 渲染 + LLM 不可绕开。
+ *
+ * Six logical fields:
+ *   - operationType / actionFamily / capabilityId — routing + debug taxonomy
+ *   - target — kind="vault-path" plus folder + filename for the modal layout
+ *   - contentPreview — full body + byteSize for observability
+ *   - impact — three booleans driving the modal Impact section icons
+ *   - riskNotes — optional one-line warnings (callouts in the modal)
+ *   - confirmCopy — i18n button labels supplied by the capability
  */
 export interface PreviewSpec {
-    target: { path: string; category: string };
-    contentMarkdown: string;
-    impact: string;
-    risk: string;
-    action: string;
+    operationType: "create-file";
+    actionFamily: string;
+    capabilityId: string;
+    target: {
+        kind: "vault-path";
+        displayPath: string;
+        folder: string;
+        filename: string;
+    };
+    contentPreview: {
+        format: "markdown" | "plain-text";
+        body: string;
+        byteSize: number;
+    };
+    impact: {
+        usesAiProvider: boolean;
+        usesAiCredits: boolean;
+        affectsExternalState: boolean;
+    };
+    riskNotes: string[];
+    confirmCopy: { confirmLabel: string; cancelLabel: string };
 }
 
 /**
  * Preview-confirmation lifecycle 的 4 个 outcome (framework SDD §2.1)。
- * - confirmed: 用户点 "采纳"
- * - cancelled: 用户点 "取消"
- * - closed:    modal 被关闭（X 按钮 / ESC）
+ * - confirmed: 用户点主按钮
+ * - cancelled: 用户点次按钮 / ESC / ✕ / 点击 modal 外部
  * - aborted:   abort signal（turn timeout / runtime abort）
+ * - timeout:   v1 不触发；保留枚举供 Operations Agent mode (v2+) 用
  */
-export type ConfirmationOutcome = "confirmed" | "cancelled" | "closed" | "aborted";
+export type ConfirmationOutcome = "confirmed" | "cancelled" | "aborted" | "timeout";
 
 /**
  * Framework 在调用 executeWrite 时提供的辅助 hooks。
@@ -94,10 +118,27 @@ export interface WriteActionCapability extends AgentCapability {
     targetConfinement: ConfinementConfig;
 
     /**
-     * 由 framework Gate 2 (preview-confirmation lifecycle) 调用。
-     * 返回 5 区块 PreviewSpec 供 modal 渲染。MUST 是纯函数（无副作用）。
+     * 由 framework Gate 1 (target-confinement) 调用 — **同步 + 纯函数**。
      *
-     * 同时被 Gate 1 用来提取 target 候选路径（spec.target.path）。
+     * 返回 capability 计划写入的 vault-relative 目标路径，供 Gate 1 在
+     * {@link buildPreview} 之前（任何 side-effect-capable 代码运行前）对
+     * 不可信 LLM 输入做 allowlist 校验。
+     *
+     * MUST 是纯函数：不读 FS / network / vault，不抛错也不依赖 capability 状态
+     * (除非 input 显然 malformed —— 此时同步 throw 即可，framework 会按
+     * errorCategory="unknown" 处理)。
+     *
+     * 校验通过后，framework 还会断言 {@link PreviewSpec.target}.displayPath
+     * 与本方法返回的路径一致；不一致 → fail with rejected_at_confinement。
+     */
+    getTargetPath(input: unknown): string;
+
+    /**
+     * 由 framework Gate 2 (preview-confirmation lifecycle) 调用。
+     * 返回 PreviewSpec 供 modal 渲染。MUST 是纯函数（无副作用）。
+     *
+     * 调用顺序保证：Gate 1 (getTargetPath + 目标 confinement) 已通过；
+     * spec.target.displayPath 必须等于 getTargetPath(input) 的输出 (normalized)。
      */
     buildPreview(input: unknown, context: AgentCapabilityContext): Promise<PreviewSpec>;
 
@@ -135,12 +176,21 @@ export type DebugEventType =
     | "rollback.ok"
     | "rollback.fail";
 
+/**
+ * Debug emit error category (framework SDD §2.4 lines 336-339)。
+ *
+ * 与 SDD 中的 8 分类一一对应。Reserved categories:
+ * - "timeout": v1 不触发；保留供 Operations Agent mode (v2+) 用
+ */
 export type DebugErrorCategory =
-    | "rejected_at_confinement"
+    | "permission_denied"
+    | "stale_target"
+    | "schema_invalid"
+    | "user_aborted"
     | "fs_error"
-    | "policy_violation"
-    | "stale_drift"
-    | "unknown";
+    | "rejected_at_confinement"
+    | "preview_render_failed"
+    | "timeout";
 
 export interface DebugEvent {
     type: DebugEventType;


### PR DESCRIPTION
## Summary

Write Action Framework v1 — PA-level infrastructure that unifies the write path for all action capabilities. First real caller is Pagelet (review note creation), shipped in a parallel PR.

This implements the **Track A** half of the rollout plan (`docs/sdd-rollout-plan.md`). 4-gate orchestration (target-confinement → preview-confirmation → stale-reread → execute), parameterized PolicyEngine that stays 100% backward-compatible for chat runtime, and per-runtime integration with `pa-agent-runtime.ts`.

**Scope (v1):** only `create-file` action family (Pagelet `write_review_output`). `append` / `replace` / `multi-file` / `command` / `shell` / `script` are deferred to Operations Agent mode (v2+).

## Changes

- **A1 — PolicyEngine parameterization** (`policy-engine.ts`, `__tests__/policy-engine.test.ts`)
  - Adds `runKind` + `allowWrite` + `allowedActionPermissions` to `PolicyEngineOptions`
  - `kind="action"` capabilities are allowed only when `runKind="review"` AND `allowWrite=true` AND permission ∈ allowlist
  - Chat runtime behavior unchanged: 9-row decision matrix locked down in tests
- **A2 — 4 framework modules + ActionExecutor** (`src/ai-services/write-action-framework/*`)
  - `target-confinement.ts` — path normalize, allowlist, traversal/control-char/extension/length/collision guards (11 reject reasons)
  - `preview-modal.ts` — `WriteActionPreviewModal` (5-block render) + `ObsidianPreviewRenderer` (4 outcomes: confirmed/cancelled/closed/aborted) + `createMutexPreviewRenderer` (FIFO serial gate)
  - `stale-reread.ts` — mode A: snapshot at Gate 2, re-check at execute, detects folderDisappeared/folderReappeared/targetAppeared/targetDisappeared
  - `debug-observer.ts` — NoopDebugObserver (prod) + ConsoleDebugObserver (dev) + combineDebugObservers (isolation)
  - `runtime-integration.ts` — `SelfWriteRegistry` (5s TTL) + `createActionExecutor` (4-gate orchestrator)
- **A3 — pa-agent-runtime integration** (`pa-agent-runtime.ts`, `__tests__/pa-agent-runtime-write-action.test.ts`)
  - `PaAgentRuntimeOptions` += `policyOptions` + `writeAction` (both optional, default = old behavior)
  - Per-runtime singleton `SelfWriteRegistry` + `ActionExecutor` in constructor
  - `dispose()` cleans up TTL timer
  - `createWriteActionAwareToolExecutor` wraps `baseExecutor`, routes `capability.kind === "action"` to `ActionExecutor`, passes through everything else unchanged

## Decision traceability

- [[D025]] Pagelet B-full write strategy
- [[D030]] 二层命名 (Operations Agent mode → Write Action Framework v1)
- [[OQ001]] Hard blocker for Pagelet beta — resolved by this PR
- `docs/write-action-framework-sdd.md` (986 lines)
- `docs/sdd-rollout-plan.md` §3 (Track A)

## Test plan

- [x] `npx tsc -noEmit -skipLibCheck` clean
- [x] `npx jest` — 64 suites / 1014 tests green
- [x] PolicyEngine 9-row decision matrix + 5-row backward-compat smoke
- [x] 4 framework modules each have isolated specs (target-confinement / preview-modal / stale-reread / debug-observer / runtime-integration)
- [x] `pa-agent-runtime-write-action.test.ts` 6 E2E paths (happy / emit chain / chat reject / cancel / drift / passthrough / schema_invalid short-circuit)
- [ ] Chat runtime smoke in real Obsidian vault (manual, post-merge)

## Not in this PR

- Pagelet caller wiring → see parallel PR for `feat/pagelet-non-write`, then Track C C1 will glue them on master
- Operations Agent mode (v2+) — additional action families and persistent audit log

🤖 Generated with [Claude Code](https://claude.com/claude-code)