### PR TITLE
feat(framework): mirror Cf invisibles + trailing-dot/space to Gate 1 (closes #360)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file. See [standa
 
 ### Improvements
 - framework(write-action): Gate 1 now has an intrinsic top-level dotfolder denylist (`.obsidian / .git / .trash / .obsidian.bak`, NFC + case-fold) at both construction time (`validateAllowedRoots` throws `ConfinementConfigError`) and candidate-write time (`forbidden_dotfolder` reject reason). The settings-layer guard introduced in `2.2.0-beta.1` remains the first line; the framework layer is now a true defense-in-depth second line that holds even if a future capability provider bypasses the settings scrub. Closes #358.
+- framework(write-action): Gate 1 also mirrors the settings-layer Cf-category invisible-char check (ZWSP/ZWNJ/ZWJ, WJ, BOM, LRM/RLM, bidi-isolates → `invisible_chars`) and the per-segment trailing dot/space check (NTFS silent-strip bypass → `trailing_dot_or_space`). Both run at construction time via `validateAllowedRoots` and at candidate-write time in the sync validator, in lock-step with the dotfolder denylist. NFKC fullwidth lookalikes remain an accepted residual risk in both layers (see SDD §2.2). Closes #360.
 
 ## [2.2.0-beta.1](https://github.com/edonyzpc/personal-assistant/compare/2.1.2...2.2.0-beta.1) (2026-06-03)
 

--- a/docs/write-action-framework-sdd.md
+++ b/docs/write-action-framework-sdd.md
@@ -262,7 +262,7 @@ export interface TargetCheckResult {
 
 **fail closed**：任何一步失败 → outcome=`rejected_at_confinement`，debug emit 记录，无 preview 弹出。
 
-**构造期验证（issue #358 AC #1，issue #360 扩展）：** `validateAllowedRoots(roots)` 在 `buildConfinement` 内同步调用，对每个 root 顺序检查 `invisible_chars` → 任一段为 `..` 的 `parent_traversal` → 每段 `trailing_dot_or_space` → `segments[0]` 在 `FORBIDDEN_DOTFOLDER_SEGMENTS`（NFC + lowercase fold）→ 命中任一立即 throw `ConfinementConfigError`（不是 silent 降级），`reason` 字段记录具体类。Pagelet 当前路径下 `normalizeReviewsFolder` 已上游兜底，此 throw 是 defense-in-depth assert，正常代码路径下不会触发。
+**构造期验证（issue #358 AC #1，issue #360 + round-1 review 扩展）：** `validateAllowedRoots(roots)` 在 `buildConfinement` 内同步调用，对每个 root 顺序检查 `control_char` → `invisible_chars` → `absolute_path` → `drive_letter` → 任一段为 `..` 的 `parent_traversal` → 每段 `trailing_dot_or_space` → `segments[0]` 在 `FORBIDDEN_DOTFOLDER_SEGMENTS`（NFC + lowercase fold）→ 命中任一立即 throw `ConfinementConfigError`（不是 silent 降级），`reason` 字段记录具体类。检查序列与 `validateTargetConfinementSync` 的前 7 步严格 mirror，所以 "defense-in-depth second line" 对任一被两侧共同覆盖的 reject reason 都是 true parity。Pagelet 当前路径下 `normalizeReviewsFolder` 已上游兜底，此 throw 是 defense-in-depth assert，正常代码路径下不会触发。
 
 **触发时机与 caller 模式（重要）：** "构造期" 指 `buildConfinement` 被调用的那一刻——具体落在哪个时间点取决于 caller 怎么暴露 `targetConfinement`：
 

--- a/docs/write-action-framework-sdd.md
+++ b/docs/write-action-framework-sdd.md
@@ -233,7 +233,8 @@ export interface TargetCheckResult {
     normalizedPath?: string;                    // 通过时返回
     reason?: string;                            // 失败时给 errorCategory 用
     category?: "empty_path" | "absolute_path" | "drive_letter"
-             | "parent_traversal" | "control_char" | "forbidden_dotfolder"
+             | "parent_traversal" | "control_char" | "invisible_chars"
+             | "trailing_dot_or_space" | "forbidden_dotfolder"
              | "outside_allowlist" | "bad_extension" | "path_too_long"
              | "custom_pattern_rejected" | "name_collision" | "folder_missing";
 }
@@ -243,21 +244,25 @@ export interface TargetCheckResult {
 
 1. **Empty**：null/undefined/空串/纯空白 → reject `empty_path`
 2. **Control chars**：`[\x00-\x1f]` → reject `control_char`
-3. **Absolute path**：前导 `/` → reject `absolute_path`
-4. **Drive letter**：`^[a-zA-Z]:` → reject `drive_letter`
-5. **Normalize**：`\` → `/`、剥离前导 `./`、collapse `/+`、剥离尾随 `/`
-6. **Parent traversal**：任一段为 `..` → reject `parent_traversal`
-7. **Forbidden dotfolder**：`segments[0].normalize("NFC").toLowerCase()` ∈ `{.obsidian, .git, .trash, .obsidian.bak}` → reject `forbidden_dotfolder`（内建 denylist，与 settings-layer `src/settings/pagelet/index.ts:344-353` mirror — defense-in-depth：即使 caller 错配 `allowedRoots`，candidate 落入禁止段照样拒）
-8. **Length cap**：normalized 长度 ≤ `maxPathLength`（默认 200）
-9. **Allowlist**：normalizedPath 必须以 `allowedRoots` 中任一前缀开头
-10. **Extension**：必须在 `allowedExtensions`
-11. **Custom rejectPatterns**：caller 自定义 RegExp（caller 通过 `ConfinementConfig.rejectPatterns` 注入；framework 不提供默认值）
-12. **(async) Folder 检查**：父目录必须存在 → reject `folder_missing`
-13. **(async) Collision 检查**：`vault.adapter.exists(normalizedPath)` 为 false（v1 create-file 不覆盖；Pagelet D008 已有"撞名自动避让"策略，但属 caller 责任，framework 仅报 collision）
+3. **Invisible chars**：Cf-category 子集 ZWSP/ZWNJ/ZWJ/WJ/BOM/LRM/RLM/bidi-isolates 任一出现 → reject `invisible_chars`（raw 阶段拦 identifier spoofing，例如 `​.obsidian` 视觉读作 `.obsidian` 但会绕过 segment-equality；与 settings-layer `src/settings/pagelet/index.ts:287` mirror）
+4. **Absolute path**：前导 `/` → reject `absolute_path`
+5. **Drive letter**：`^[a-zA-Z]:` → reject `drive_letter`
+6. **Normalize**：`\` → `/`、剥离前导 `./`、collapse `/+`、剥离尾随 `/`
+7. **Parent traversal**：任一段为 `..` → reject `parent_traversal`
+8. **Trailing dot or space**：任一段末尾匹配 `[.\s]` → reject `trailing_dot_or_space`（NTFS 在 OS 层会静默剥离 trailing `.` / space，所以 `.obsidian./plugins` 实际 dispatch 到真正的 `.obsidian/plugins`；**必须**在 forbidden_dotfolder 之前，否则 spoof segment 不命中 fold 后漏出；与 settings-layer `src/settings/pagelet/index.ts:330` mirror）
+9. **Forbidden dotfolder**：`segments[0].normalize("NFC").toLowerCase()` ∈ `{.obsidian, .git, .trash, .obsidian.bak}` → reject `forbidden_dotfolder`（内建 denylist，与 settings-layer `src/settings/pagelet/index.ts:344-353` mirror — defense-in-depth：即使 caller 错配 `allowedRoots`，candidate 落入禁止段照样拒）
+10. **Length cap**：normalized 长度 ≤ `maxPathLength`（默认 200）
+11. **Allowlist**：normalizedPath 必须以 `allowedRoots` 中任一前缀开头
+12. **Extension**：必须在 `allowedExtensions`
+13. **Custom rejectPatterns**：caller 自定义 RegExp（caller 通过 `ConfinementConfig.rejectPatterns` 注入；framework 不提供默认值）
+14. **(async) Folder 检查**：父目录必须存在 → reject `folder_missing`
+15. **(async) Collision 检查**：`vault.adapter.exists(normalizedPath)` 为 false（v1 create-file 不覆盖；Pagelet D008 已有"撞名自动避让"策略，但属 caller 责任，framework 仅报 collision）
+
+**NFC 残余风险（issue #360）：** invisible_chars / trailing_dot_or_space / forbidden_dotfolder 三步都在 NFC + lowercase fold 路径里跑，与 settings 层一致。NFKC fullwidth 变体（如 `．ｏｂｓｉｄｉａｎ`，U+FF0E + fullwidth letters）当前**不**拦截——可接受，因为 Obsidian / APFS / NTFS dispatch 规则不会把 fullwidth 折成 ASCII。如果未来真遇到 OS dispatch fullwidth → ASCII 的现实案例，**两层必须 lock-step 升到 NFKC**（settings + framework 同时改），否则会重新打开 issue #358 关掉的那类 bypass。
 
 **fail closed**：任何一步失败 → outcome=`rejected_at_confinement`，debug emit 记录，无 preview 弹出。
 
-**构造期验证（issue #358 AC #1）：** `validateAllowedRoots(roots)` 在 `buildConfinement` 内同步调用，对每个 root 做相同的 NFC+lowercase fold 检查；命中 `FORBIDDEN_DOTFOLDER_SEGMENTS` 直接 throw `ConfinementConfigError`（不是 silent 降级）。Pagelet 当前路径下 `normalizeReviewsFolder` 已上游兜底，此 throw 是 defense-in-depth assert，正常代码路径下不会触发。
+**构造期验证（issue #358 AC #1，issue #360 扩展）：** `validateAllowedRoots(roots)` 在 `buildConfinement` 内同步调用，对每个 root 顺序检查 `invisible_chars` → 任一段为 `..` 的 `parent_traversal` → 每段 `trailing_dot_or_space` → `segments[0]` 在 `FORBIDDEN_DOTFOLDER_SEGMENTS`（NFC + lowercase fold）→ 命中任一立即 throw `ConfinementConfigError`（不是 silent 降级），`reason` 字段记录具体类。Pagelet 当前路径下 `normalizeReviewsFolder` 已上游兜底，此 throw 是 defense-in-depth assert，正常代码路径下不会触发。
 
 **触发时机与 caller 模式（重要）：** "构造期" 指 `buildConfinement` 被调用的那一刻——具体落在哪个时间点取决于 caller 怎么暴露 `targetConfinement`：
 

--- a/src/ai-services/write-action-framework/target-confinement.spec.ts
+++ b/src/ai-services/write-action-framework/target-confinement.spec.ts
@@ -435,6 +435,48 @@ describe("validateAllowedRoots (framework SDD §2.2 / issue #358 AC #1)", () => 
         }
     });
 
+    // Issue #360 round-1 review collateral: register-side now mirrors the
+    // sync-side control_char / absolute_path / drive_letter checks so the
+    // "defense-in-depth second line" promise is true parity rather than the
+    // narrower invisible_chars + trailing_dot_or_space mirror originally
+    // scoped for #360.
+    it("throws control_char when an allowed root contains a NUL byte", () => {
+        const root = ".pagelet\x00/";
+        try {
+            validateAllowedRoots([root]);
+            throw new Error("should have thrown");
+        } catch (err) {
+            expect(err).toBeInstanceOf(ConfinementConfigError);
+            const e = err as ConfinementConfigError;
+            expect(e.reason).toBe("control_char");
+            expect(e.offendingRoot).toBe(root);
+        }
+    });
+
+    it("throws absolute_path when an allowed root starts with /", () => {
+        try {
+            validateAllowedRoots(["/etc/pagelet/"]);
+            throw new Error("should have thrown");
+        } catch (err) {
+            expect(err).toBeInstanceOf(ConfinementConfigError);
+            const e = err as ConfinementConfigError;
+            expect(e.reason).toBe("absolute_path");
+            expect(e.offendingRoot).toBe("/etc/pagelet/");
+        }
+    });
+
+    it("throws drive_letter when an allowed root is Windows-rooted (C:/...)", () => {
+        try {
+            validateAllowedRoots(["C:/Users/x/"]);
+            throw new Error("should have thrown");
+        } catch (err) {
+            expect(err).toBeInstanceOf(ConfinementConfigError);
+            const e = err as ConfinementConfigError;
+            expect(e.reason).toBe("drive_letter");
+            expect(e.offendingRoot).toBe("C:/Users/x/");
+        }
+    });
+
     // Issue #360 collateral: register-side now mirrors the sync-side
     // parent_traversal check too (was missing in #358's minimal scope —
     // surfaced by the prompt-injection fixture for `../../config.json`).

--- a/src/ai-services/write-action-framework/target-confinement.spec.ts
+++ b/src/ai-services/write-action-framework/target-confinement.spec.ts
@@ -151,6 +151,97 @@ describe("validateTargetConfinementSync (framework SDD §2.2)", () => {
         expect(result).toEqual({ ok: true, normalizedPath: "notes/.obsidian-cheatsheet/tips.md" });
     });
 
+    // invisible_chars — Cf-category spoof defense (issue #360). Mirror of
+    // settings-layer `src/settings/pagelet/index.ts:287`. Fires on RAW input
+    // BEFORE normalize so a ZWSP-prefixed `.obsidian` does not slip past the
+    // dotfolder denylist by being a different literal string.
+    it("rejects invisible_chars for ZWSP prefix on .obsidian (the canonical spoof)", () => {
+        // The whole point of this defense: must report `invisible_chars`,
+        // NOT `forbidden_dotfolder`, because the segment is `​.obsidian`
+        // (with the zero-width prefix) and the fold check would never match
+        // `.obsidian`. The check order in the validator is what catches this.
+        const result = validateTargetConfinementSync("​.obsidian/plugins/x.md", baseConfig);
+        expect(result).toMatchObject({ ok: false, reason: "invisible_chars" });
+    });
+
+    it("rejects invisible_chars for ZWNJ / ZWJ / WJ / BOM variants", () => {
+        for (const ch of ["‌", "‍", "⁠", "﻿"]) {
+            const path = `.pagelet/no${ch}te.md`;
+            expect(validateTargetConfinementSync(path, baseConfig)).toMatchObject({
+                ok: false,
+                reason: "invisible_chars",
+            });
+        }
+    });
+
+    it("rejects invisible_chars for LRM / RLM directional marks", () => {
+        for (const ch of ["‎", "‏"]) {
+            const path = `.pagelet/n${ch}ote.md`;
+            expect(validateTargetConfinementSync(path, baseConfig)).toMatchObject({
+                ok: false,
+                reason: "invisible_chars",
+            });
+        }
+    });
+
+    it("rejects invisible_chars for bidi-isolate marks (U+2066–U+2069)", () => {
+        const path = `.pagelet/⁦hidden.md⁩`;
+        expect(validateTargetConfinementSync(path, baseConfig)).toMatchObject({
+            ok: false,
+            reason: "invisible_chars",
+        });
+    });
+
+    // trailing_dot_or_space — NTFS-bypass defense (issue #360). Mirror of
+    // settings-layer `src/settings/pagelet/index.ts:330`. MUST fire BEFORE
+    // forbidden_dotfolder so `.obsidian./...` reports the actual spoof class.
+    it("rejects trailing_dot_or_space for .obsidian./plugins (the canonical NTFS spoof)", () => {
+        // Critical-order test: `.obsidian.` would not match the fold so it
+        // would slip past forbidden_dotfolder — but NTFS would still route
+        // the write to the real `.obsidian/`. Must report
+        // `trailing_dot_or_space`, NOT `forbidden_dotfolder`.
+        const result = validateTargetConfinementSync(".obsidian./plugins/x.md", baseConfig);
+        expect(result).toMatchObject({
+            ok: false,
+            reason: "trailing_dot_or_space",
+            detail: ".obsidian.",
+        });
+    });
+
+    it("rejects trailing_dot_or_space for trailing dot on a nested segment", () => {
+        expect(validateTargetConfinementSync(".pagelet/sub./file.md", baseConfig)).toMatchObject({
+            ok: false,
+            reason: "trailing_dot_or_space",
+            detail: "sub.",
+        });
+    });
+
+    it("rejects trailing_dot_or_space for trailing space on a nested segment", () => {
+        expect(validateTargetConfinementSync(".pagelet/sub /file.md", baseConfig)).toMatchObject({
+            ok: false,
+            reason: "trailing_dot_or_space",
+            detail: "sub ",
+        });
+    });
+
+    it("rejects trailing_dot_or_space for trailing NBSP (\\s covers U+00A0)", () => {
+        // Tab/CR/LF would be eaten by the earlier `control_char` step (they're
+        // in [\x00-\x1f]); NBSP isn't a control char but `\s` matches it, so
+        // it's the right witness for "trailing whitespace beyond ASCII space".
+        expect(validateTargetConfinementSync(".pagelet/sub /file.md", baseConfig)).toMatchObject({
+            ok: false,
+            reason: "trailing_dot_or_space",
+            detail: "sub ",
+        });
+    });
+
+    it("does NOT trip trailing_dot_or_space when a segment ends in a normal char", () => {
+        // Sanity: only literal trailing `.` or `\s` matches; a normal filename
+        // like `foo.md` ends in `d`, not `.` or whitespace.
+        const result = validateTargetConfinementSync(".pagelet/notes/foo.md", baseConfig);
+        expect(result).toEqual({ ok: true, normalizedPath: ".pagelet/notes/foo.md" });
+    });
+
     it("rejects path_too_long when normalized path exceeds maxPathLength", () => {
         const longName = "a".repeat(300);
         const result = validateTargetConfinementSync(`.pagelet/${longName}.md`, baseConfig);
@@ -342,5 +433,78 @@ describe("validateAllowedRoots (framework SDD §2.2 / issue #358 AC #1)", () => 
             expect((err as Error).message).toContain(".obsidian");
             expect((err as Error).message).toContain("forbidden_dotfolder");
         }
+    });
+
+    // Issue #360 collateral: register-side now mirrors the sync-side
+    // parent_traversal check too (was missing in #358's minimal scope —
+    // surfaced by the prompt-injection fixture for `../../config.json`).
+    it("throws parent_traversal when an allowed root contains a `..` segment", () => {
+        try {
+            validateAllowedRoots(["../../config.json/"]);
+            throw new Error("should have thrown");
+        } catch (err) {
+            expect(err).toBeInstanceOf(ConfinementConfigError);
+            const e = err as ConfinementConfigError;
+            expect(e.reason).toBe("parent_traversal");
+            expect(e.offendingSegment).toBe("..");
+        }
+    });
+
+    // Issue #360: register-time mirrors of the two new sync-side reasons.
+    it("throws invisible_chars for a root containing a ZWSP", () => {
+        const root = "​.pagelet/";
+        try {
+            validateAllowedRoots([root]);
+            throw new Error("should have thrown");
+        } catch (err) {
+            expect(err).toBeInstanceOf(ConfinementConfigError);
+            const e = err as ConfinementConfigError;
+            expect(e.reason).toBe("invisible_chars");
+            expect(e.offendingRoot).toBe(root);
+        }
+    });
+
+    it("throws trailing_dot_or_space when a top-level root segment ends in space", () => {
+        try {
+            validateAllowedRoots([".pagelet /"]);
+            throw new Error("should have thrown");
+        } catch (err) {
+            expect(err).toBeInstanceOf(ConfinementConfigError);
+            const e = err as ConfinementConfigError;
+            expect(e.reason).toBe("trailing_dot_or_space");
+            expect(e.offendingSegment).toBe(".pagelet ");
+        }
+    });
+
+    it("throws trailing_dot_or_space when a NESTED root segment ends in dot", () => {
+        try {
+            validateAllowedRoots([".pagelet/sub./"]);
+            throw new Error("should have thrown");
+        } catch (err) {
+            expect(err).toBeInstanceOf(ConfinementConfigError);
+            const e = err as ConfinementConfigError;
+            expect(e.reason).toBe("trailing_dot_or_space");
+            expect(e.offendingSegment).toBe("sub.");
+        }
+    });
+
+    it("throws trailing_dot_or_space (NOT forbidden_dotfolder) for .obsidian./plugins/", () => {
+        // Order assertion: the same critical-order property as the sync side.
+        // `.obsidian.` would not match the dotfolder fold; the trailing check
+        // must run first or the spoof slips through.
+        try {
+            validateAllowedRoots([".obsidian./plugins/"]);
+            throw new Error("should have thrown");
+        } catch (err) {
+            const e = err as ConfinementConfigError;
+            expect(e.reason).toBe("trailing_dot_or_space");
+        }
+    });
+
+    it("does NOT trip trailing_dot_or_space on the empty terminal segment of `.pagelet/`", () => {
+        // Defensive check: roots conventionally end in `/`, splitting to
+        // [".pagelet", ""]. The empty terminal must be skipped so legitimate
+        // roots aren't rejected.
+        expect(() => validateAllowedRoots([".pagelet/"])).not.toThrow();
     });
 });

--- a/src/ai-services/write-action-framework/target-confinement.ts
+++ b/src/ai-services/write-action-framework/target-confinement.ts
@@ -125,11 +125,33 @@ export function validateAllowedRoots(allowedRoots: readonly string[]): void {
     for (const root of allowedRoots) {
         if (typeof root !== "string" || root.length === 0) continue;
 
-        // Mirror sync step 2.5: invisible_chars on raw root, before any
+        // Mirror sync step 1: control_char on raw root, before any normalization.
+        // Catches NUL / 0x01–0x1F smuggled into the allowlist at construction
+        // time so a misconfigured caller cannot slip past the candidate-side
+        // guard via a sanitizer that strips control chars from the candidate
+        // but trusts the root verbatim.
+        // eslint-disable-next-line no-control-regex
+        if (/[\x00-\x1f]/.test(root)) {
+            throw new ConfinementConfigError("control_char", root, root);
+        }
+
+        // Mirror sync step 1.5: invisible_chars on raw root, before any
         // normalization. Surface the offending root unchanged so a maintainer
         // can paste it back into a hex inspector if the byte is non-printable.
         if (INVISIBLE_CHARS_RE.test(root)) {
             throw new ConfinementConfigError("invisible_chars", root, root);
+        }
+
+        // Mirror sync step 2: absolute_path. A root anchored at filesystem
+        // root would let any candidate that prefix-matches it escape the vault.
+        if (root.startsWith("/")) {
+            throw new ConfinementConfigError("absolute_path", root, root);
+        }
+
+        // Mirror sync step 3: drive_letter (Windows). Same escape-the-vault
+        // concern as absolute_path on POSIX.
+        if (/^[a-zA-Z]:/.test(root)) {
+            throw new ConfinementConfigError("drive_letter", root, root);
         }
 
         const normalized = root.replace(/\\/g, "/").replace(/^\.\//, "");
@@ -196,6 +218,7 @@ export function validateTargetConfinementSync(
 
     // 1. Control characters (NUL through 0x1F). Detect on raw input before any
     // normalization to catch payloads that try to smuggle bytes past trim/replace.
+    // eslint-disable-next-line no-control-regex
     if (/[\x00-\x1f]/.test(candidate)) {
         return { ok: false, reason: "control_char" };
     }

--- a/src/ai-services/write-action-framework/target-confinement.ts
+++ b/src/ai-services/write-action-framework/target-confinement.ts
@@ -25,6 +25,8 @@ export type ConfinementRejectReason =
     | "drive_letter"
     | "parent_traversal"
     | "control_char"
+    | "invisible_chars"
+    | "trailing_dot_or_space"
     | "forbidden_dotfolder"
     | "outside_allowlist"
     | "bad_extension"
@@ -49,6 +51,36 @@ const FORBIDDEN_DOTFOLDER_SEGMENTS: ReadonlySet<string> = new Set([
     ".trash",
     ".obsidian.bak",
 ]);
+
+/**
+ * Cf-category invisible characters used for identifier spoofing — ZWSP/ZWNJ/ZWJ
+ * (U+200B-U+200D), WJ (U+2060), BOM/ZWNBSP (U+FEFF), LRM/RLM (U+200E/U+200F),
+ * bidi-formats (U+202A-U+202E), bidi-isolates (U+2066-U+2069). Pattern is
+ * verbatim-equal to the settings-layer source at
+ * `src/settings/pagelet/index.ts:287` so a future audit can grep both sides
+ * and confirm parity. Rejects e.g. a path with a leading ZWSP before
+ * `.obsidian` (visually reads `.obsidian/...` but bypasses the literal
+ * segment-equality check below).
+ *
+ * NFC residual risk (issue #360 Option A): fullwidth lookalikes like
+ * U+FF0E + fullwidth letters survive both this check and the NFC +
+ * lowercase fold path used by `FORBIDDEN_DOTFOLDER_SEGMENTS`. Acceptable
+ * today because Obsidian / APFS / NTFS dispatch rules don't fold fullwidth
+ * → ASCII. If that ever changes, upgrade BOTH this layer AND the
+ * settings-layer fold to NFKC in lock-step (see SDD §2.2 note).
+ */
+const INVISIBLE_CHARS_RE =
+    /[\u200b-\u200d\u2060\ufeff\u200e\u200f\u202a-\u202e\u2066-\u2069]/;
+
+/**
+ * Trailing dot or whitespace per segment. NTFS silently strips trailing `.` /
+ * space at the OS layer, so `.obsidian./plugins/x.md` dispatches to the real
+ * `.obsidian/plugins/x.md` despite the literal segment guard below seeing
+ * `.obsidian.` (not equal to `.obsidian`). Same class of bypass for trailing
+ * tab/NBSP via `\s`. Verbatim copy of the settings-layer pattern at
+ * `src/settings/pagelet/index.ts:330`.
+ */
+const TRAILING_DOT_OR_SPACE_RE = /[.\s]$/;
 
 export type ConfinementResult =
     | { ok: true; normalizedPath: string }
@@ -92,8 +124,35 @@ export class ConfinementConfigError extends Error {
 export function validateAllowedRoots(allowedRoots: readonly string[]): void {
     for (const root of allowedRoots) {
         if (typeof root !== "string" || root.length === 0) continue;
+
+        // Mirror sync step 2.5: invisible_chars on raw root, before any
+        // normalization. Surface the offending root unchanged so a maintainer
+        // can paste it back into a hex inspector if the byte is non-printable.
+        if (INVISIBLE_CHARS_RE.test(root)) {
+            throw new ConfinementConfigError("invisible_chars", root, root);
+        }
+
         const normalized = root.replace(/\\/g, "/").replace(/^\.\//, "");
-        const firstSegment = normalized.split("/")[0] ?? "";
+        const segments = normalized.split("/");
+
+        // Mirror sync step 5: parent traversal. Any literal `..` segment
+        // would route an allowlist-anchored write outside the vault root,
+        // so reject before checking trailing-char shapes (otherwise the
+        // `..` ends-in-dot property reports the wrong reason).
+        if (segments.some((segment) => segment === "..")) {
+            throw new ConfinementConfigError("parent_traversal", root, "..");
+        }
+
+        // Mirror sync step 6.5: trailing dot/space on any non-empty segment.
+        // `.pagelet/` splits to [".pagelet", ""] — skip the empty terminal
+        // segment so a legitimate trailing slash on a root doesn't trip.
+        for (const segment of segments) {
+            if (segment.length > 0 && TRAILING_DOT_OR_SPACE_RE.test(segment)) {
+                throw new ConfinementConfigError("trailing_dot_or_space", root, segment);
+            }
+        }
+
+        const firstSegment = segments[0] ?? "";
         const folded = firstSegment.normalize("NFC").toLowerCase();
         if (FORBIDDEN_DOTFOLDER_SEGMENTS.has(folded)) {
             throw new ConfinementConfigError("forbidden_dotfolder", root, firstSegment);
@@ -119,9 +178,10 @@ export const DEFAULT_MAX_PATH_LENGTH = 200;
  * concrete reason wins (e.g., an absolute path containing control chars
  * reports `absolute_path` first).
  *
- * Order: empty → control_char → absolute → drive_letter → normalize →
- *        parent_traversal → forbidden_dotfolder → length → allowlist →
- *        extension → custom rejectPatterns.
+ * Order: empty → control_char → invisible_chars → absolute → drive_letter →
+ *        normalize → parent_traversal → trailing_dot_or_space →
+ *        forbidden_dotfolder → length → allowlist → extension →
+ *        custom rejectPatterns.
  */
 export function validateTargetConfinementSync(
     candidate: string,
@@ -138,6 +198,15 @@ export function validateTargetConfinementSync(
     // normalization to catch payloads that try to smuggle bytes past trim/replace.
     if (/[\x00-\x1f]/.test(candidate)) {
         return { ok: false, reason: "control_char" };
+    }
+
+    // 1.5. Cf-category invisible chars (ZWSP/ZWNJ/ZWJ, WJ, BOM, LRM/RLM,
+    // bidi-isolates). Raw-input check so a ZWSP prefix on `.obsidian` is
+    // rejected here instead of leaking through to the segment-equality check
+    // that wouldn't match the spoofed string. Mirror of settings-layer
+    // `src/settings/pagelet/index.ts:287`.
+    if (INVISIBLE_CHARS_RE.test(candidate)) {
+        return { ok: false, reason: "invisible_chars" };
     }
 
     // 2. Absolute path (POSIX-style leading "/").
@@ -162,6 +231,17 @@ export function validateTargetConfinementSync(
     const segments = normalized.split("/");
     if (segments.some((segment) => segment === "..")) {
         return { ok: false, reason: "parent_traversal" };
+    }
+
+    // 5.5. Trailing dot or whitespace per segment. MUST run before the
+    // forbidden_dotfolder check below — otherwise `.obsidian./plugins/x.md`
+    // would slip past the segment-equality fold (`.obsidian.` ≠ `.obsidian`)
+    // and only NTFS would stop it at OS layer (which it does silently, by
+    // dispatching the write into the real `.obsidian/`). Mirror of
+    // settings-layer `src/settings/pagelet/index.ts:330`.
+    const trailingOffender = segments.find((segment) => TRAILING_DOT_OR_SPACE_RE.test(segment));
+    if (trailingOffender !== undefined) {
+        return { ok: false, reason: "trailing_dot_or_space", detail: trailingOffender };
     }
 
     // 6. Forbidden top-level dotfolder. Intrinsic denylist that fires

--- a/src/ai-services/write-action-framework/target-confinement.ts
+++ b/src/ai-services/write-action-framework/target-confinement.ts
@@ -117,15 +117,17 @@ export class ConfinementConfigError extends Error {
  * fold — is in {@link FORBIDDEN_DOTFOLDER_SEGMENTS}. Runs at
  * `buildConfinement` time so a misconfigured caller fails LOUDLY at
  * capability registration, not silently at first write. Mirrors the
- * candidate-side denylist in {@link validateTargetConfinementSync} step 6:
+ * candidate-side denylist in {@link validateTargetConfinementSync} step 9:
  * both sides reject the same input set so the framework remains a true
- * second line of defense regardless of caller wiring.
+ * second line of defense regardless of caller wiring. Step numbers throughout
+ * track SDD §2.2's 1–13 sync sequence (steps 14–15 are async folder/collision
+ * probes that only the {@link validateTargetConfinement} wrapper runs).
  */
 export function validateAllowedRoots(allowedRoots: readonly string[]): void {
     for (const root of allowedRoots) {
         if (typeof root !== "string" || root.length === 0) continue;
 
-        // Mirror sync step 1: control_char on raw root, before any normalization.
+        // Mirror sync step 2: control_char on raw root, before any normalization.
         // Catches NUL / 0x01–0x1F smuggled into the allowlist at construction
         // time so a misconfigured caller cannot slip past the candidate-side
         // guard via a sanitizer that strips control chars from the candidate
@@ -135,29 +137,37 @@ export function validateAllowedRoots(allowedRoots: readonly string[]): void {
             throw new ConfinementConfigError("control_char", root, root);
         }
 
-        // Mirror sync step 1.5: invisible_chars on raw root, before any
+        // Mirror sync step 3: invisible_chars on raw root, before any
         // normalization. Surface the offending root unchanged so a maintainer
         // can paste it back into a hex inspector if the byte is non-printable.
         if (INVISIBLE_CHARS_RE.test(root)) {
             throw new ConfinementConfigError("invisible_chars", root, root);
         }
 
-        // Mirror sync step 2: absolute_path. A root anchored at filesystem
+        // Mirror sync step 4: absolute_path. A root anchored at filesystem
         // root would let any candidate that prefix-matches it escape the vault.
         if (root.startsWith("/")) {
             throw new ConfinementConfigError("absolute_path", root, root);
         }
 
-        // Mirror sync step 3: drive_letter (Windows). Same escape-the-vault
+        // Mirror sync step 5: drive_letter (Windows). Same escape-the-vault
         // concern as absolute_path on POSIX.
         if (/^[a-zA-Z]:/.test(root)) {
             throw new ConfinementConfigError("drive_letter", root, root);
         }
 
-        const normalized = root.replace(/\\/g, "/").replace(/^\.\//, "");
+        // Mirror sync step 6: same normalize shape on both sides (backslash →
+        // `/`, strip leading `./`, collapse repeated `//`). The `/+/g` collapse
+        // is load-bearing — without it `notes//foo/` splits to
+        // `["notes", "", "foo", ""]` and a future segment check that forgets to
+        // skip empties would either misreport or silently let bad input through.
+        const normalized = root
+            .replace(/\\/g, "/")
+            .replace(/^\.\//, "")
+            .replace(/\/+/g, "/");
         const segments = normalized.split("/");
 
-        // Mirror sync step 5: parent traversal. Any literal `..` segment
+        // Mirror sync step 7: parent traversal. Any literal `..` segment
         // would route an allowlist-anchored write outside the vault root,
         // so reject before checking trailing-char shapes (otherwise the
         // `..` ends-in-dot property reports the wrong reason).
@@ -165,9 +175,11 @@ export function validateAllowedRoots(allowedRoots: readonly string[]): void {
             throw new ConfinementConfigError("parent_traversal", root, "..");
         }
 
-        // Mirror sync step 6.5: trailing dot/space on any non-empty segment.
-        // `.pagelet/` splits to [".pagelet", ""] — skip the empty terminal
-        // segment so a legitimate trailing slash on a root doesn't trip.
+        // Mirror sync step 8: trailing dot/space per segment. After the `/+/g`
+        // collapse above, the only empty segment that can survive is the
+        // terminal one from a legitimate trailing slash (e.g. `.pagelet/`
+        // splits to `[".pagelet", ""]`), so `length > 0` is a convention guard,
+        // not a normalization workaround.
         for (const segment of segments) {
             if (segment.length > 0 && TRAILING_DOT_OR_SPACE_RE.test(segment)) {
                 throw new ConfinementConfigError("trailing_dot_or_space", root, segment);
@@ -216,14 +228,15 @@ export function validateTargetConfinementSync(
         return { ok: false, reason: "empty_path" };
     }
 
-    // 1. Control characters (NUL through 0x1F). Detect on raw input before any
+    // 2. Control characters (NUL through 0x1F). Detect on raw input before any
     // normalization to catch payloads that try to smuggle bytes past trim/replace.
+    // (Step 1 — empty/whitespace — is the two `empty_path` returns above.)
     // eslint-disable-next-line no-control-regex
     if (/[\x00-\x1f]/.test(candidate)) {
         return { ok: false, reason: "control_char" };
     }
 
-    // 1.5. Cf-category invisible chars (ZWSP/ZWNJ/ZWJ, WJ, BOM, LRM/RLM,
+    // 3. Cf-category invisible chars (ZWSP/ZWNJ/ZWJ, WJ, BOM, LRM/RLM,
     // bidi-isolates). Raw-input check so a ZWSP prefix on `.obsidian` is
     // rejected here instead of leaking through to the segment-equality check
     // that wouldn't match the spoofed string. Mirror of settings-layer
@@ -232,17 +245,17 @@ export function validateTargetConfinementSync(
         return { ok: false, reason: "invisible_chars" };
     }
 
-    // 2. Absolute path (POSIX-style leading "/").
+    // 4. Absolute path (POSIX-style leading "/").
     if (candidate.startsWith("/")) {
         return { ok: false, reason: "absolute_path" };
     }
 
-    // 3. Windows drive letter (e.g., "C:/...", "c:\..."). Catch before normalize.
+    // 5. Windows drive letter (e.g., "C:/...", "c:\..."). Catch before normalize.
     if (/^[a-zA-Z]:/.test(candidate)) {
         return { ok: false, reason: "drive_letter" };
     }
 
-    // 4. Normalize: convert backslashes to forward slashes (Obsidian uses POSIX
+    // 6. Normalize: convert backslashes to forward slashes (Obsidian uses POSIX
     // separators), strip leading "./", collapse repeated "//".
     let normalized = candidate.replace(/\\/g, "/").replace(/^\.\//, "").replace(/\/+/g, "/");
     // Strip a trailing slash so extension check has a real filename to inspect.
@@ -250,13 +263,13 @@ export function validateTargetConfinementSync(
         normalized = normalized.slice(0, -1);
     }
 
-    // 5. Parent traversal: any segment equal to ".." (covers "../x", "a/../b", "a/..").
+    // 7. Parent traversal: any segment equal to ".." (covers "../x", "a/../b", "a/..").
     const segments = normalized.split("/");
     if (segments.some((segment) => segment === "..")) {
         return { ok: false, reason: "parent_traversal" };
     }
 
-    // 5.5. Trailing dot or whitespace per segment. MUST run before the
+    // 8. Trailing dot or whitespace per segment. MUST run before the
     // forbidden_dotfolder check below — otherwise `.obsidian./plugins/x.md`
     // would slip past the segment-equality fold (`.obsidian.` ≠ `.obsidian`)
     // and only NTFS would stop it at OS layer (which it does silently, by
@@ -267,27 +280,27 @@ export function validateTargetConfinementSync(
         return { ok: false, reason: "trailing_dot_or_space", detail: trailingOffender };
     }
 
-    // 6. Forbidden top-level dotfolder. Intrinsic denylist that fires
+    // 9. Forbidden top-level dotfolder. Intrinsic denylist that fires
     // BEFORE the allowlist check, so a caller with a misconfigured
     // `allowedRoots = [".obsidian/plugins/x/"]` cannot pass a candidate
     // under `.obsidian/...` through. NFC + lowercase mirrors the
     // settings-layer validator at `src/settings/pagelet/index.ts:344`
     // so both layers fail the same inputs (APFS/NTFS case-insensitive
     // dispatch, NFD variants). Backslash inputs are already collapsed
-    // to "/" by step 4, so `.git\evil.md` is `segments[0] === ".git"`
+    // to "/" by step 6, so `.git\evil.md` is `segments[0] === ".git"`
     // by the time we reach this check.
     const firstSegmentFolded = (segments[0] ?? "").normalize("NFC").toLowerCase();
     if (FORBIDDEN_DOTFOLDER_SEGMENTS.has(firstSegmentFolded)) {
         return { ok: false, reason: "forbidden_dotfolder", detail: segments[0] };
     }
 
-    // 7. Length cap.
+    // 10. Length cap.
     const maxLength = config.maxPathLength ?? DEFAULT_MAX_PATH_LENGTH;
     if (normalized.length > maxLength) {
         return { ok: false, reason: "path_too_long", detail: `${normalized.length} > ${maxLength}` };
     }
 
-    // 8. Allowlist: normalizedPath must start with one of the allowed roots.
+    // 11. Allowlist: normalizedPath must start with one of the allowed roots.
     if (!config.allowedRoots || config.allowedRoots.length === 0) {
         return { ok: false, reason: "outside_allowlist", detail: "no allowedRoots configured" };
     }
@@ -299,7 +312,7 @@ export function validateTargetConfinementSync(
         return { ok: false, reason: "outside_allowlist" };
     }
 
-    // 9. Extension.
+    // 12. Extension.
     const lastDot = normalized.lastIndexOf(".");
     const lastSlash = normalized.lastIndexOf("/");
     const ext = lastDot > lastSlash ? normalized.substring(lastDot) : "";
@@ -310,7 +323,7 @@ export function validateTargetConfinementSync(
         return { ok: false, reason: "bad_extension", detail: `got "${ext}"` };
     }
 
-    // 10. Custom reject patterns (caller extensibility; runs after built-in checks).
+    // 13. Custom reject patterns (caller extensibility; runs after built-in checks).
     if (config.rejectPatterns) {
         for (const pattern of config.rejectPatterns) {
             if (pattern.test(normalized) || pattern.test(candidate)) {


### PR DESCRIPTION
## Summary

Closes #360. Adds two anti-spoofing checks to the Write Action Framework's target-confinement gate, mirroring the settings-layer guards landed in v2.2.0-beta.1. Follow-up to PR #359 (closes #358) which mirrored the dotfolder denylist — this PR completes the framework↔settings parity for the three settings-layer anti-spoofing categories.

**New reject reasons:**
- `invisible_chars` — Cf-category subset (ZWSP/ZWNJ/ZWJ, WJ, BOM, LRM/RLM, bidi-isolates). Rejects e.g. a ZWSP-prefixed `.obsidian` that would otherwise bypass literal segment-equality.
- `trailing_dot_or_space` — per segment, `/[.\s]$/`. Rejects the NTFS-bypass class where `.obsidian./plugins/x.md` silently dispatches to the real `.obsidian/plugins/x.md` at the OS layer. **Order matters** — runs before `forbidden_dotfolder` so `.obsidian.` reports the actual spoof class instead of falling through.

**Mirrored on both API surfaces:**
- `validateTargetConfinementSync` — sync candidate-side check; `invisible_chars` after `control_char` on raw input; `trailing_dot_or_space` after `parent_traversal`.
- `validateAllowedRoots` — register-time check; throws `ConfinementConfigError` with the offending root + segment.

**Incidental scope expansion (architectural parity):** `validateAllowedRoots` had no `parent_traversal` check (issue #358's minimal scope left it out). Surfaced by the `inject-traversal` prompt-injection fixture: `../../config.json/` config triggers register-time check, where `..` ends in `.` and tripped `trailing_dot_or_space` instead of `parent_traversal`. Sync-side already had the check — adding it to register-side restores fixture semantics and brings the two API surfaces to true parity.

## NFKC decision (issue #360 round-1 comment)

**Option A** — keep NFC + lowercase fold parity with the settings layer; document NFKC fullwidth lookalikes (e.g. `．ｏｂｓｉｄｉａｎ`) as accepted residual risk in both the code comment and SDD §2.2. If OS dispatch ever folds fullwidth → ASCII, **both layers must be upgraded to NFKC in lock-step** or the issue #358 bypass class re-opens.

## Test plan

- [x] `npx jest src/ai-services/write-action-framework/target-confinement.spec.ts` — 55/55 (was 40 pre-PR; +15 new covering all Cf families, top/nested trailing dot/space, register-side throws, plus negatives).
- [x] `npx jest __tests__/pagelet-prompt-injection.spec.ts` — 9/9 (no fixture changes required after the register-side `parent_traversal` addition).
- [x] `npx jest` full suite — 1535/1535 (was 1520; +15).
- [x] `npx tsc --noEmit --skipLibCheck` — clean.
- [x] `npx eslint src/ai-services/write-action-framework/target-confinement.ts` — clean except a pre-existing `no-control-regex` error at the original step-1 control_char check (present on master, not introduced by this PR).
- [x] Grep parity check: `INVISIBLE_CHARS_RE` uses identical Unicode escapes as `src/settings/pagelet/index.ts:287`; `TRAILING_DOT_OR_SPACE_RE` is the same `/[.\s]$/` as `src/settings/pagelet/index.ts:330`.

## Out of scope

- NFKC upgrade — deferred per Option A.
- Settings-layer changes — already has these checks; parity preserved.
- User-facing i18n — Gate 1 is debug-tag-only by design (`runtime-integration.ts:271-296` is a passthrough).
- Caller wiring (`pa-review-tool-provider.ts:285` already calls `validateAllowedRoots`, automatically picks up the new checks at construction time).

🤖 Generated with [Claude Code](https://claude.com/claude-code)