### PR TITLE
[codex] v2.8.1 feedback fixes

### DIFF
--- a/__tests__/get-vss-files.test.ts
+++ b/__tests__/get-vss-files.test.ts
@@ -61,6 +61,7 @@ jest.mock('../src/settings', () => ({
 }));
 jest.mock('../src/local-graph', () => ({ LocalGraph: class { } }));
 jest.mock('../src/utils', () => ({
+    KEYCHAIN_API_TOKEN_ID: 'pa-api-token',
     getVaultApiTokenId: () => 'pa-api-token',
     hasSecretValue: () => false,
     icons: {},

--- a/__tests__/memory-manager.test.ts
+++ b/__tests__/memory-manager.test.ts
@@ -514,6 +514,29 @@ describe('MemoryManager command decisions', () => {
         await first;
     });
 
+    it('resets the manual command guard when the wrapped command throws', async () => {
+        const plugin = createPlugin(createPlan({
+            reason: 'first-use',
+            action: 'rebuild',
+            requiresApproval: true,
+        }));
+        plugin.vss.getMemoryReadiness.mockRejectedValueOnce(new Error('boom'));
+        const manager = createManager(plugin);
+
+        await expect(manager.prepareFromCommand()).rejects.toThrow('boom');
+        mockNoticeMessages.length = 0;
+
+        plugin.vss.getMemoryReadiness.mockResolvedValueOnce(createPlan({
+            reason: 'ready',
+            action: 'none',
+            requiresApproval: false,
+            canAnswerNow: true,
+        }));
+        await manager.prepareFromCommand();
+
+        expect(mockNoticeMessages).not.toContain('A Memory action is already running.');
+    });
+
     it('updates one progress notice from rebuild progress events', async () => {
         let now = 0;
         const nowSpy = jest.spyOn(Date, 'now').mockImplementation(() => {

--- a/__tests__/memory-manager.test.ts
+++ b/__tests__/memory-manager.test.ts
@@ -482,6 +482,38 @@ describe('MemoryManager command decisions', () => {
         ]);
     });
 
+    it('ignores repeated manual prepare clicks while a command is already in flight', async () => {
+        let releasePlan!: () => void;
+        const planGate = new Promise<void>((resolve) => {
+            releasePlan = resolve;
+        });
+        const plugin = createPlugin(createPlan({
+            reason: 'first-use',
+            action: 'rebuild',
+            requiresApproval: true,
+        }));
+        plugin.vss.getMemoryReadiness.mockImplementation(async () => {
+            await planGate;
+            return createPlan({
+                reason: 'first-use',
+                action: 'rebuild',
+                requiresApproval: true,
+            });
+        });
+        const manager = createManager(plugin);
+        (manager as any).requestApproval = jest.fn(async () => 'answer-now'); // eslint-disable-line @typescript-eslint/no-explicit-any
+
+        const first = manager.prepareFromCommand();
+        await Promise.resolve();
+        await manager.prepareFromCommand();
+
+        expect(mockNoticeMessages).toEqual(['A Memory action is already running.']);
+        expect(plugin.vss.getMemoryReadiness).toHaveBeenCalledTimes(1);
+
+        releasePlan();
+        await first;
+    });
+
     it('updates one progress notice from rebuild progress events', async () => {
         let now = 0;
         const nowSpy = jest.spyOn(Date, 'now').mockImplementation(() => {

--- a/__tests__/pagelet-background-preparation-coordinator.test.ts
+++ b/__tests__/pagelet-background-preparation-coordinator.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it, jest } from "@jest/globals";
+
+import { BackgroundPreparationCoordinator } from "../src/pagelet/BackgroundPreparationCoordinator";
+import type { PreloadEvent, PreloadResult } from "../src/pagelet/preload/types";
+
+function makeCoordinator() {
+    const callbacks = {
+        onPetTransition: jest.fn(),
+        onPetFlashError: jest.fn(),
+        onInsightsReady: jest.fn(() => true),
+    };
+    const coordinator = new BackgroundPreparationCoordinator(
+        { log: jest.fn(), settings: { pagelet: {} } } as never,
+        {} as never,
+        {} as never,
+        {} as never,
+        {} as never,
+        callbacks,
+    );
+    const internals = coordinator as unknown as {
+        handleEvent(event: PreloadEvent): void;
+    };
+    return { callbacks, internals };
+}
+
+function preloadResult(findings: PreloadResult["findings"]): PreloadResult {
+    return {
+        findings,
+        analyzedFiles: ["notes/current.md"],
+        analyzedAt: Date.now(),
+        tokenCost: { input: 10, output: 5 },
+    };
+}
+
+describe("BackgroundPreparationCoordinator", () => {
+    it("does not enter nudge when a completed background cycle has no findings", () => {
+        const { callbacks, internals } = makeCoordinator();
+
+        internals.handleEvent({
+            type: "cycle-complete",
+            result: preloadResult([]),
+        });
+
+        expect(callbacks.onInsightsReady).not.toHaveBeenCalled();
+        expect(callbacks.onPetTransition).toHaveBeenCalledWith("analysis-done");
+        expect(callbacks.onPetTransition).not.toHaveBeenCalledWith("insights-ready");
+    });
+
+    it("enters insights-ready only when findings exist and proactive hints accept them", () => {
+        const { callbacks, internals } = makeCoordinator();
+
+        internals.handleEvent({
+            type: "cycle-complete",
+            result: preloadResult([{
+                text: "Prepared finding",
+                sourceFile: "notes/current.md",
+                sourceTitle: "current",
+            }]),
+        });
+
+        expect(callbacks.onInsightsReady).toHaveBeenCalledTimes(1);
+        expect(callbacks.onPetTransition).toHaveBeenCalledWith("insights-ready");
+    });
+});

--- a/__tests__/pagelet-background-preparation-coordinator.test.ts
+++ b/__tests__/pagelet-background-preparation-coordinator.test.ts
@@ -46,6 +46,24 @@ describe("BackgroundPreparationCoordinator", () => {
         expect(callbacks.onPetTransition).not.toHaveBeenCalledWith("insights-ready");
     });
 
+    it("falls back to analysis-done when findings exist but onInsightsReady returns false", () => {
+        const { callbacks, internals } = makeCoordinator();
+        callbacks.onInsightsReady.mockReturnValue(false);
+
+        internals.handleEvent({
+            type: "cycle-complete",
+            result: preloadResult([{
+                text: "Suppressed finding",
+                sourceFile: "notes/current.md",
+                sourceTitle: "current",
+            }]),
+        });
+
+        expect(callbacks.onInsightsReady).toHaveBeenCalledTimes(1);
+        expect(callbacks.onPetTransition).toHaveBeenCalledWith("analysis-done");
+        expect(callbacks.onPetTransition).not.toHaveBeenCalledWith("insights-ready");
+    });
+
     it("enters insights-ready only when findings exist and proactive hints accept them", () => {
         const { callbacks, internals } = makeCoordinator();
 

--- a/__tests__/pagelet-bubble-content.test.ts
+++ b/__tests__/pagelet-bubble-content.test.ts
@@ -95,4 +95,16 @@ describe("Pagelet Bubble quick access content", () => {
 
         expect(callbacks.onExpandPanel).toHaveBeenCalledWith("prepared");
     });
+
+    it("does not offer prepared suggestions when a nudge has no findings", () => {
+        const callbacks = makeCallbacks();
+        const content = buildNudgeContent([], callbacks, "en");
+
+        expect(content.actions.map((action) => action.label)).toEqual(["Later"]);
+
+        content.actions[0].callback();
+
+        expect(callbacks.onExpandPanel).not.toHaveBeenCalled();
+        expect(callbacks.onDismiss).toHaveBeenCalledTimes(1);
+    });
 });

--- a/__tests__/pagelet-orchestrator.test.ts
+++ b/__tests__/pagelet-orchestrator.test.ts
@@ -27,7 +27,7 @@ jest.mock("obsidian", () => {
     };
 });
 
-import { TFile } from "obsidian";
+import { Notice, TFile } from "obsidian";
 
 import { PageletOrchestrator, type PageletHost } from "../src/pagelet/orchestrator";
 import type { PageletDetailPayload } from "../src/pagelet/tab/types";
@@ -530,6 +530,20 @@ describe("PageletOrchestrator detail expansion", () => {
 });
 
 describe("PageletOrchestrator review panel scope flow", () => {
+    it("does not open an empty prepared-findings panel", () => {
+        const host = makeHost();
+        const orchestrator = new PageletOrchestrator(host);
+        const panelView = { open: jest.fn() };
+        (orchestrator as unknown as { panelView: typeof panelView }).panelView = panelView;
+
+        (orchestrator as unknown as {
+            handleExpandPanel(type?: string): void;
+        }).handleExpandPanel("prepared");
+
+        expect(panelView.open).not.toHaveBeenCalled();
+        expect(Notice).toHaveBeenCalledWith("No background suggestions are available yet.", 4000);
+    });
+
     it("opens the review panel without treating preload findings as saveable review output", () => {
         const host = makeHost();
         const orchestrator = new PageletOrchestrator(host);

--- a/__tests__/plugin-record-note.test.ts
+++ b/__tests__/plugin-record-note.test.ts
@@ -734,6 +734,27 @@ describe('manual Memory action guard', () => {
         expect(secondAction).toHaveBeenCalledTimes(1);
     });
 
+    it('releases the guard when the action rejects', async () => {
+        mockNoticeMessages.length = 0;
+        const plugin = Object.create(PluginManager.prototype) as any; // eslint-disable-line @typescript-eslint/no-explicit-any
+        plugin.t = jest.fn((key: string) => (
+            key === 'plugin.memory.notice.actionAlreadyRunning'
+                ? 'A Memory action is already running.'
+                : key
+        ));
+
+        const failingAction = jest.fn(async () => {
+            throw new Error('boom');
+        });
+        await expect(plugin.runManualMemoryAction(failingAction)).rejects.toThrow('boom');
+
+        const followUp = jest.fn(async () => undefined);
+        await plugin.runManualMemoryAction(followUp);
+
+        expect(followUp).toHaveBeenCalledTimes(1);
+        expect(mockNoticeMessages).toEqual([]);
+    });
+
     it('shares the manual Memory guard with Chat memory actions', async () => {
         mockNoticeMessages.length = 0;
         const plugin = Object.create(PluginManager.prototype) as any; // eslint-disable-line @typescript-eslint/no-explicit-any
@@ -808,6 +829,58 @@ describe('API token secret compatibility', () => {
         expect(plugin.app.secretStorage.setSecret).not.toHaveBeenCalled();
         expect(secrets.has('pa-api-token-vault-id')).toBe(false);
         expect(plugin.log).not.toHaveBeenCalled();
+    });
+
+    it('falls back to the default-vault scoped token when the current scoped id is empty', () => {
+        const secrets = new Map<string, string>([
+            ['pa-api-token-default-vault', 'sk-default-vault-token'],
+        ]);
+        const plugin = Object.create(PluginManager.prototype) as any; // eslint-disable-line @typescript-eslint/no-explicit-any
+        plugin.settings = { statisticsVaultId: 'vault-id' };
+        plugin.app = {
+            secretStorage: {
+                getSecret: jest.fn((id: string) => secrets.get(id) ?? null),
+                setSecret: jest.fn(),
+            },
+        };
+        plugin.log = jest.fn();
+
+        expect(plugin.getConfiguredAPITokenSecret()).toBe('sk-default-vault-token');
+
+        expect(plugin.app.secretStorage.setSecret).not.toHaveBeenCalled();
+    });
+
+    it('returns null when all candidate secret ids are empty', () => {
+        const plugin = Object.create(PluginManager.prototype) as any; // eslint-disable-line @typescript-eslint/no-explicit-any
+        plugin.settings = { statisticsVaultId: 'vault-id' };
+        plugin.app = {
+            secretStorage: {
+                getSecret: jest.fn(() => null),
+                setSecret: jest.fn(),
+            },
+        };
+        plugin.log = jest.fn();
+
+        expect(plugin.getConfiguredAPITokenSecret()).toBeNull();
+        expect(plugin.app.secretStorage.setSecret).not.toHaveBeenCalled();
+    });
+
+    it('writes only the current scoped id when setting a non-empty token', () => {
+        const plugin = Object.create(PluginManager.prototype) as any; // eslint-disable-line @typescript-eslint/no-explicit-any
+        plugin.settings = { statisticsVaultId: 'vault-id' };
+        plugin.token = 'cached';
+        plugin.app = {
+            secretStorage: {
+                getSecret: jest.fn(() => null),
+                setSecret: jest.fn(),
+            },
+        };
+
+        plugin.setAPITokenSecret('sk-new-token');
+
+        expect(plugin.app.secretStorage.setSecret).toHaveBeenCalledTimes(1);
+        expect(plugin.app.secretStorage.setSecret).toHaveBeenCalledWith('pa-api-token-vault-id', 'sk-new-token');
+        expect(plugin.token).toBe('');
     });
 
     it('clears current and legacy API token secret ids together', () => {

--- a/__tests__/plugin-record-note.test.ts
+++ b/__tests__/plugin-record-note.test.ts
@@ -143,6 +143,7 @@ jest.mock('../src/settings', () => ({
 }));
 jest.mock('../src/local-graph', () => ({ LocalGraph: class { } }));
 jest.mock('../src/utils', () => ({
+    KEYCHAIN_API_TOKEN_ID: 'pa-api-token',
     getVaultApiTokenId: (vaultId?: string) => vaultId ? `pa-api-token-${vaultId}` : 'pa-api-token',
     hasSecretValue: (value: string | null) => value !== null && value !== '',
     icons: {},
@@ -696,6 +697,134 @@ describe('Pagelet detail workspace leaf', () => {
             type: 'pa-pagelet-detail-view',
             active: true,
         });
+    });
+});
+
+describe('manual Memory action guard', () => {
+    it('prevents a second manual Memory action while the first one is still running', async () => {
+        mockNoticeMessages.length = 0;
+        const plugin = Object.create(PluginManager.prototype) as any; // eslint-disable-line @typescript-eslint/no-explicit-any
+        plugin.t = jest.fn((key: string) => (
+            key === 'plugin.memory.notice.actionAlreadyRunning'
+                ? 'A Memory action is already running.'
+                : key
+        ));
+
+        let releaseFirstAction!: () => void;
+        const firstActionDone = new Promise<void>((resolve) => {
+            releaseFirstAction = resolve;
+        });
+        const firstAction = jest.fn(async () => {
+            await firstActionDone;
+        });
+        const secondAction = jest.fn(async () => undefined);
+
+        const firstRun = plugin.runManualMemoryAction(firstAction);
+        expect(firstAction).toHaveBeenCalledTimes(1);
+
+        await plugin.runManualMemoryAction(secondAction);
+
+        expect(secondAction).not.toHaveBeenCalled();
+        expect(mockNoticeMessages).toEqual(['A Memory action is already running.']);
+
+        releaseFirstAction();
+        await firstRun;
+        await plugin.runManualMemoryAction(secondAction);
+
+        expect(secondAction).toHaveBeenCalledTimes(1);
+    });
+
+    it('shares the manual Memory guard with Chat memory actions', async () => {
+        mockNoticeMessages.length = 0;
+        const plugin = Object.create(PluginManager.prototype) as any; // eslint-disable-line @typescript-eslint/no-explicit-any
+        plugin.app = {};
+        plugin.settings = {};
+        plugin.chatHistoryManager = {};
+        plugin.log = jest.fn();
+        plugin.t = jest.fn((key: string) => (
+            key === 'plugin.memory.notice.actionAlreadyRunning'
+                ? 'A Memory action is already running.'
+                : key
+        ));
+        plugin.getAISetupIssue = jest.fn(() => null);
+        plugin.showTechnicalMemoryStatus = jest.fn(async () => undefined);
+        plugin.onMemoryStatusChanged = jest.fn(() => jest.fn());
+        plugin.onSettingsChanged = jest.fn(() => jest.fn());
+        plugin.scheduleMemoryExtractionAfterChatTurn = jest.fn();
+        plugin.createAiServiceHost = jest.fn(() => ({}));
+
+        let releaseChatAction!: () => void;
+        const chatActionDone = new Promise<void>((resolve) => {
+            releaseChatAction = resolve;
+        });
+        plugin.memoryManager = {
+            getMaintenancePlan: jest.fn(async () => ({
+                reason: 'ready',
+                action: 'none',
+                notesToCheck: 0,
+                requiresApproval: false,
+                canAnswerNow: true,
+            })),
+            updateFromCommand: jest.fn(async () => {
+                await chatActionDone;
+            }),
+            prepareFromCommand: jest.fn(async () => undefined),
+        };
+
+        const host = plugin.createChatHost();
+        const chatRun = host.memoryStatus.updateFromCommand();
+        expect(plugin.memoryManager.updateFromCommand).toHaveBeenCalledTimes(1);
+
+        const settingsAction = jest.fn(async () => undefined);
+        await plugin.runManualMemoryAction(settingsAction);
+
+        expect(settingsAction).not.toHaveBeenCalled();
+        expect(mockNoticeMessages).toEqual(['A Memory action is already running.']);
+
+        releaseChatAction();
+        await chatRun;
+    });
+});
+
+describe('API token secret compatibility', () => {
+    it('reads a legacy keychain token without mutating secret storage', () => {
+        const secrets = new Map<string, string>([
+            ['pa-api-token', 'sk-legacy-token'],
+        ]);
+        const plugin = Object.create(PluginManager.prototype) as any; // eslint-disable-line @typescript-eslint/no-explicit-any
+        plugin.settings = { statisticsVaultId: 'vault-id' };
+        plugin.app = {
+            secretStorage: {
+                getSecret: jest.fn((id: string) => secrets.get(id) ?? null),
+                setSecret: jest.fn((id: string, value: string) => {
+                    secrets.set(id, value);
+                }),
+            },
+        };
+        plugin.log = jest.fn();
+
+        expect(plugin.getConfiguredAPITokenSecret()).toBe('sk-legacy-token');
+
+        expect(plugin.app.secretStorage.setSecret).not.toHaveBeenCalled();
+        expect(secrets.has('pa-api-token-vault-id')).toBe(false);
+        expect(plugin.log).not.toHaveBeenCalled();
+    });
+
+    it('clears current and legacy API token secret ids together', () => {
+        const plugin = Object.create(PluginManager.prototype) as any; // eslint-disable-line @typescript-eslint/no-explicit-any
+        plugin.settings = { statisticsVaultId: 'vault-id' };
+        plugin.app = {
+            secretStorage: {
+                getSecret: jest.fn(() => null),
+                setSecret: jest.fn(),
+            },
+        };
+
+        plugin.setAPITokenSecret('');
+
+        expect(plugin.app.secretStorage.setSecret).toHaveBeenCalledWith('pa-api-token-vault-id', '');
+        expect(plugin.app.secretStorage.setSecret).toHaveBeenCalledWith('pa-api-token-default-vault', '');
+        expect(plugin.app.secretStorage.setSecret).toHaveBeenCalledWith('pa-api-token', '');
     });
 });
 

--- a/__tests__/settings.test.ts
+++ b/__tests__/settings.test.ts
@@ -329,12 +329,6 @@ jest.mock('../src/stats-view', () => ({ STAT_PREVIEW_TYPE: 'stat-preview' }));
 jest.mock('../src/stats/stats-store', () => ({ normalizeStatisticsView: (view: string) => view }));
 jest.mock('../src/utils', () => ({
     KEYCHAIN_API_TOKEN_ID: 'pa-api-token',
-    getVaultScopedSecret: (
-        secretStorage: { getSecret: (id: string) => string | null },
-        scopedId: string,
-    ) => {
-        return secretStorage.getSecret(scopedId);
-    },
     hasSecretValue: (secret: string | null) => secret !== null && secret !== '',
 }));
 
@@ -588,6 +582,7 @@ function makePlugin(overrides: Partial<typeof DEFAULT_SETTINGS> = {}) {
 beforeEach(() => {
     getMockSettingRecords().length = 0;
     getMockDebounceRecords().length = 0;
+    delete (globalThis as typeof globalThis & { __paModalInstances?: unknown[] }).__paModalInstances;
     installMockDocument();
 });
 
@@ -2069,7 +2064,7 @@ describe('Phase 4 P1 UX', () => {
             await clickMemoryButton('Delete old Memory cache files');
             await clickMemoryButton('Show technical memory status');
 
-            expect(plugin.runManualMemoryAction).toHaveBeenCalledTimes(5);
+            expect(plugin.runManualMemoryAction).toHaveBeenCalledTimes(4);
             expect(plugin.memoryManager.updateFromCommand).toHaveBeenCalledTimes(1);
             expect(plugin.memoryManager.prepareFromCommand).toHaveBeenCalledTimes(1);
             expect(plugin.vss.resetLocalIndex).toHaveBeenCalledTimes(1);

--- a/__tests__/settings.test.ts
+++ b/__tests__/settings.test.ts
@@ -51,6 +51,24 @@ jest.mock('obsidian', () => ({
         containerEl = { empty: jest.fn() };
         constructor(app: unknown, _plugin: unknown) { this.app = app; }
     },
+    Modal: class {
+        app: unknown;
+        contentEl: HTMLElement;
+        constructor(app: unknown) {
+            this.app = app;
+            this.contentEl = document.createElement('div');
+        }
+        open() {
+            const globalObj = globalThis as typeof globalThis & { __paModalInstances?: unknown[] };
+            globalObj.__paModalInstances = globalObj.__paModalInstances ?? [];
+            globalObj.__paModalInstances.push(this);
+            (this as unknown as { onOpen?: () => void }).onOpen?.();
+            return this;
+        }
+        close() {
+            (this as unknown as { onClose?: () => void }).onClose?.();
+        }
+    },
     Setting: class {
         record: {
             name?: string;
@@ -97,6 +115,10 @@ jest.mock('obsidian', () => ({
             return this;
         }
 
+        setHeading() {
+            return this;
+        }
+
         addToggle(callback: (toggle: {
             setValue: (value: boolean) => unknown;
             setDisabled: (disabled: boolean) => unknown;
@@ -127,6 +149,7 @@ jest.mock('obsidian', () => ({
         }
 
         addText(callback: (text: {
+            inputEl: HTMLInputElement & { addClass: (cls: string) => unknown };
             setPlaceholder: (value: string) => unknown;
             setValue: (value: unknown) => unknown;
             onChange: (onChange: (value: string) => unknown) => unknown;
@@ -138,13 +161,24 @@ jest.mock('obsidian', () => ({
                 setValueCalls: unknown[];
             } = { setValueCalls: [] };
             this.record.texts.push(text);
+            const inputEl = {
+                readOnly: false,
+                type: 'text',
+                value: '',
+                addClass: jest.fn(),
+                dispatchEvent: jest.fn(),
+                focus: jest.fn(),
+                select: jest.fn(),
+            } as unknown as HTMLInputElement & { addClass: (cls: string) => unknown };
             const textComponent = {
+                inputEl,
                 setPlaceholder: (value: string) => {
                     text.placeholder = value;
                     return textComponent;
                 },
                 setValue: (value: unknown) => {
                     text.value = value;
+                    inputEl.value = String(value ?? '');
                     text.setValueCalls.push(value);
                     return textComponent;
                 },
@@ -294,6 +328,7 @@ jest.mock('../src/confirm', () => {
 jest.mock('../src/stats-view', () => ({ STAT_PREVIEW_TYPE: 'stat-preview' }));
 jest.mock('../src/stats/stats-store', () => ({ normalizeStatisticsView: (view: string) => view }));
 jest.mock('../src/utils', () => ({
+    KEYCHAIN_API_TOKEN_ID: 'pa-api-token',
     getVaultScopedSecret: (
         secretStorage: { getSecret: (id: string) => string | null },
         scopedId: string,
@@ -356,6 +391,11 @@ class MockDomNode {
 
     setAttr(name: string, value: string) {
         this.attrs[name] = value;
+        return this;
+    }
+
+    addClass(cls: string) {
+        this.classes.push(cls);
         return this;
     }
 
@@ -528,6 +568,7 @@ function makePlugin(overrides: Partial<typeof DEFAULT_SETTINGS> = {}) {
             scheduleAutoFlush: jest.fn(),
         },
         updateMemoryStatusBar: jest.fn(async () => undefined),
+        runManualMemoryAction: jest.fn(async (action: () => Promise<void>) => { await action(); }),
         vss: {
             resetLocalIndex: jest.fn(async () => undefined),
             cleanLegacyJsonCache: jest.fn(async () => undefined),
@@ -536,6 +577,8 @@ function makePlugin(overrides: Partial<typeof DEFAULT_SETTINGS> = {}) {
         canShowAiInsights: jest.fn(() => true),
         showAiInsights: jest.fn(),
         getAPITokenSecretId: jest.fn(() => 'pa-api-token-vault-test'),
+        getConfiguredAPITokenSecret: jest.fn<() => string | null>(() => null),
+        setAPITokenSecret: jest.fn(),
         statsManager: {
             setStatisticsSyncEnabled: jest.fn(async () => undefined),
         },
@@ -1556,6 +1599,7 @@ describe('Phase 3 IA reorder + provider UX', () => {
 
         expect(confirmUserAction).not.toHaveBeenCalled();
         expect(app.secretStorage.setSecret).not.toHaveBeenCalled();
+        expect(plugin.setAPITokenSecret).not.toHaveBeenCalled();
         expect(plugin.clearTokenCache).not.toHaveBeenCalled();
     });
 
@@ -1563,9 +1607,7 @@ describe('Phase 3 IA reorder + provider UX', () => {
         setMockConfirmDecision(false);
         const plugin = makePlugin({ aiProvider: 'qwen' });
         const app = makeMockApp();
-        app.secretStorage.getSecret.mockImplementation((id: string) => (
-            id === 'pa-api-token-vault-test' ? 'sk-existing-token' : null
-        ));
+        plugin.getConfiguredAPITokenSecret.mockReturnValue('sk-existing-token');
         const tab = new SettingTab(app as never, plugin as never);
         tab.containerEl = new MockContainerEl('div') as never;
         tab.display();
@@ -1577,17 +1619,16 @@ describe('Phase 3 IA reorder + provider UX', () => {
 
         expect(confirmUserAction).toHaveBeenCalledTimes(1);
         expect(app.secretStorage.setSecret).not.toHaveBeenCalled();
+        expect(plugin.setAPITokenSecret).not.toHaveBeenCalled();
         expect(secret.value).toBe('sk-existing-token');
         expect(plugin.clearTokenCache).not.toHaveBeenCalled();
     });
 
-    it('clears scoped API token id after confirmation', async () => {
+    it('clears API token through the plugin secret helper after confirmation', async () => {
         setMockConfirmDecision(true);
         const plugin = makePlugin({ aiProvider: 'qwen' });
         const app = makeMockApp();
-        app.secretStorage.getSecret.mockImplementation((id: string) => (
-            id === 'pa-api-token-vault-test' ? 'sk-existing-token' : null
-        ));
+        plugin.getConfiguredAPITokenSecret.mockReturnValue('sk-existing-token');
         const tab = new SettingTab(app as never, plugin as never);
         tab.containerEl = new MockContainerEl('div') as never;
         tab.display();
@@ -1596,8 +1637,43 @@ describe('Phase 3 IA reorder + provider UX', () => {
 
         await secret.onChange!('');
 
-        expect(app.secretStorage.setSecret).toHaveBeenCalledWith('pa-api-token-vault-test', '');
-        expect(plugin.clearTokenCache).toHaveBeenCalled();
+        expect(plugin.setAPITokenSecret).toHaveBeenCalledWith('');
+    });
+
+    it('refreshes the visible token row after saving through the custom API token modal', async () => {
+        let storedToken: string | null = null;
+        const plugin = makePlugin({ aiProvider: 'qwen' });
+        const app = makeMockApp();
+        plugin.getConfiguredAPITokenSecret.mockImplementation(() => storedToken);
+        plugin.setAPITokenSecret.mockImplementation((value: unknown) => {
+            const token = String(value);
+            storedToken = token === '' ? null : token;
+        });
+        const tab = new SettingTab(app as never, plugin as never);
+        tab.containerEl = new MockContainerEl('div') as never;
+        tab.display();
+
+        expect(getMockSecretRecords()).toHaveLength(1);
+        expect(getMockSecretRecords()[0].value).toBeUndefined();
+
+        (tab as unknown as { openApiTokenSecretEditor(): void }).openApiTokenSecretEditor();
+        const modalSecretInput = getMockSettingRecords()
+            .flatMap((record) => record.texts)
+            .find((text) => text.placeholder === 'sk-...');
+        expect(modalSecretInput?.onChange).toBeDefined();
+        modalSecretInput!.onChange!('sk-modal-token');
+
+        const saveButton = [...getMockSettingRecords()]
+            .reverse()
+            .flatMap((record) => record.buttons)
+            .find((button) => button.text === 'Save');
+        expect(saveButton?.onClick).toBeDefined();
+        await saveButton!.onClick!();
+
+        expect(plugin.setAPITokenSecret).toHaveBeenCalledWith('sk-modal-token');
+        const secretRecords = getMockSecretRecords();
+        expect(secretRecords).toHaveLength(2);
+        expect(secretRecords[1].value).toBe('sk-modal-token');
     });
 });
 
@@ -1970,6 +2046,36 @@ describe('Phase 4 P1 UX', () => {
 
             expect(confirmUserAction).not.toHaveBeenCalled();
             expect(plugin.settings.memoryApprovalPolicy).toBe('always');
+        });
+
+        it('routes manual advanced Memory buttons through the shared action guard', async () => {
+            (confirmUserAction as jest.Mock).mockClear();
+            setMockConfirmDecision(true);
+            const plugin = makePlugin({ showAdvancedMemoryControls: true });
+            const tab = new SettingTab(makeMockApp() as never, plugin as never);
+            tab.containerEl = new MockContainerEl('div') as never;
+            tab.display();
+
+            const clickMemoryButton = async (name: string) => {
+                const button = getMockSettingRecords()
+                    .find((r) => r.name === name)?.buttons[0];
+                expect(button?.onClick).toBeDefined();
+                await button!.onClick!();
+            };
+
+            await clickMemoryButton('Update memory now');
+            await clickMemoryButton('Rebuild memory on this device');
+            await clickMemoryButton('Reset local memory copy');
+            await clickMemoryButton('Delete old Memory cache files');
+            await clickMemoryButton('Show technical memory status');
+
+            expect(plugin.runManualMemoryAction).toHaveBeenCalledTimes(5);
+            expect(plugin.memoryManager.updateFromCommand).toHaveBeenCalledTimes(1);
+            expect(plugin.memoryManager.prepareFromCommand).toHaveBeenCalledTimes(1);
+            expect(plugin.vss.resetLocalIndex).toHaveBeenCalledTimes(1);
+            expect(plugin.vss.cleanLegacyJsonCache).toHaveBeenCalledTimes(1);
+            expect(plugin.showTechnicalMemoryStatus).toHaveBeenCalledTimes(1);
+            expect(confirmUserAction).toHaveBeenCalledTimes(1);
         });
     });
 

--- a/docs/v2.8.1-feedback-fix-plan.md
+++ b/docs/v2.8.1-feedback-fix-plan.md
@@ -1,0 +1,377 @@
+# v2.8.1 Feedback Fix Plan
+
+## Status
+
+| Field | Value |
+| --- | --- |
+| Track | v2.8.1 product polish and validation |
+| Status | Draft repair plan |
+| Created | 2026-06-22 |
+| Source signal | Latest-version usage feedback: Settings API token, Memory local storage lock, Pagelet resting state, Pagelet background preparation, and recent review empty state |
+
+This plan turns the latest usage feedback into scoped repair work. It does not
+change the product boundary: PA remains one plugin with AI Chat, Memory,
+Pagelet, Statistics, and Obsidian read tools. It also keeps Pagelet background
+preparation as an opt-in performance feature, not autonomous note editing.
+
+## Product Problem Summary
+
+Feedback says the current version is functionally on track, but several product
+details are not yet trustworthy or legible:
+
+1. Settings API token configuration is awkward, and the configured token appears
+   to be lost after reload.
+2. Memory management can show a local storage locked state.
+3. It is unclear when Pagelet enters the sleeping/resting state.
+4. Pagelet background preparation has not been fully validated.
+5. `View suggestions` can open a `Recent Review` panel with empty content.
+6. The user cannot easily tell what Pagelet background preparation is doing.
+
+## Reported Reproduction Notes
+
+- API token: the first configured token was wrong and produced a `401`. The
+  user then switched provider, restarted the app at least once, and saw the
+  token configuration appear lost.
+- Empty prepared suggestions: the user saw the green Pagelet hint dot, clicked
+  through, and the resulting content was empty. Background status was not
+  checked at the time.
+- Memory locked: after first configuring an API token, the user clicked
+  rebuild Memory several times.
+
+## Current Implementation Findings
+
+### Settings API Token
+
+- Runtime token storage is already vault-scoped SecretStorage, not normal
+  `data.json` settings. `PluginManager.getAPITokenSecretId()` derives the
+  current secret id from `statisticsVaultId`, and `getAPIToken()` reads
+  `app.secretStorage`.
+- Settings renders an API token `SecretComponent`, then intercepts the native
+  `Link...` button to open a custom add/edit token modal.
+- Current token reads and writes should go through `PluginManager` helpers, not
+  direct Settings-level `secretStorage` calls.
+- Current source no longer contains the old v1 `settings.apiToken` decrypt-and-
+  migrate chain. That cleanup is intentional for later versions, but it means
+  old keychain ids can look like "token lost" unless the scoped secret helper
+  checks compatibility ids.
+- Existing tests cover clear confirmation and basic second-launch provider
+  migration, but they do not prove real Obsidian reload persistence for the
+  custom API-token modal.
+
+Working hypothesis:
+
+- The reload-loss symptom is likely one of:
+  - SecretStorage write/read mismatch after the custom modal path.
+  - `statisticsVaultId` or vault-scoped secret id drift in a fresh or migrated
+    vault.
+  - Token exists under the legacy global keychain id (`pa-api-token`) or the
+    transitional `default-vault` scoped id, while current code only reads the
+    current vault-scoped id.
+  - Settings UI not refreshing after a successful write, making a persisted
+    token look missing.
+  - Real Obsidian reload behavior not covered by current unit tests.
+
+First fix:
+
+- `PluginManager.getConfiguredAPITokenSecret()` now reads the current scoped
+  id first, then legacy compatibility ids, without writing during read paths.
+  This keeps Settings/command availability checks from silently migrating
+  credentials across vault scopes.
+- `PluginManager.setAPITokenSecret("")` clears current and legacy ids together
+  so an old fallback token cannot reappear after the user clears it.
+- Settings API-token UI uses those plugin helpers for display, save, and clear.
+
+### Memory Local Storage Locked
+
+- Memory durable storage uses SQLite/WASM OPFS SAH pool as a local cache.
+- Foreground chat/status paths intentionally avoid aggressive recovery when
+  local storage is locked, because recovery or rebuild can consume AI calls.
+- Manual technical diagnostics and approved prepare/update paths already allow
+  bounded retry.
+- User-facing copy currently says local storage is busy and asks the user to
+  close other Obsidian windows for the vault, but the normal Settings surface
+  does not guide the user through recovery.
+
+Working hypothesis:
+
+- The low-level lock policy is mostly right. The product gap is diagnosis and
+  recovery UX: users need to know whether Memory is temporarily busy, disabled
+  for this turn, recoverable through diagnostics, or needs explicit prepare.
+
+Button conflict audit:
+
+- `Update memory now` and `Rebuild memory on this device` call
+  `MemoryManager.updateFromCommand()` / `prepareFromCommand()`.
+- `Reset local memory copy`, `Delete old Memory cache files`, and
+  `Show technical memory status` used to call VSS/status methods directly from
+  Settings and command-palette handlers.
+- `Keep memory updated in background`, Memory model, and exclude-path controls
+  only save settings or schedule background maintenance; they are not the same
+  kind of immediate local-index mutation.
+
+First fix:
+
+- Add a shared manual Memory action guard in `PluginManager`, and route
+  Settings plus command-palette Memory actions through it.
+- Keep a narrower `MemoryManager` in-flight guard for direct prepare/update
+  calls, so repeated rebuild clicks cannot stack duplicate approval/progress
+  flows even if a caller bypasses the plugin-level command path.
+
+### Pagelet Resting State
+
+- Current product design removed `sleeping` as a separate state. The shipped
+  state is `resting`.
+- The runtime enters `resting` after 10 minutes without Markdown note activity.
+- A Markdown note modification is debounced by 5 seconds, transitions the Pet
+  back to `idle`, and notifies background preparation.
+
+Working hypothesis:
+
+- The behavior may be correct, but the product language is unclear. If users
+  say "sleeping", Settings, docs, and diagnostics should translate that into
+  `resting`, with a visible rule such as "after 10 minutes of no note activity".
+
+### Pagelet Background Preparation
+
+- Code still uses internal names `preload*`; user-facing copy says background
+  preparation.
+- The feature is opt-in and defaults off.
+- When enabled, the engine schedules the first run after the configured interval
+  instead of running immediately.
+- It analyzes changed Markdown notes from the recent 7-day scope, subject to
+  exclude rules, per-hour/day caps, and token budget.
+- Results are cached only in memory. Reloading the plugin or vault clears the
+  cache by design.
+- The status command shows running/stopped, last preparation, remaining budget,
+  and whether cache exists, but not the next run time, last skip reason, analyzed
+  file count, or last error category.
+
+Working hypothesis:
+
+- Users reasonably expect enabling background preparation to do something soon
+  and to expose evidence of what it did. Current status is too thin, and the
+  cache being session-only makes validation easy to misread after reload.
+
+### Recent Review Empty After View Suggestions
+
+- `View suggestions` opens the prepared-findings route.
+- Prepared findings come from the in-memory background cache.
+- `ProactiveHints.onInsightsReady()` currently decides whether to nudge based
+  on proactive-hint settings, cooldown, and quiet hours. It does not check that
+  the completed background cycle actually produced findings.
+- Therefore an empty AI result can still move the Pet into `nudge`; clicking
+  `View suggestions` can then open `Recent Review` with no visible findings.
+- There is also a naming mismatch: the background prompt produces lightweight
+  2-3 findings, not a full Pagelet review note. A `Recent Review` heading makes
+  empty or lightweight prepared results feel like a broken review.
+
+Working hypothesis:
+
+- This is the clearest code-level bug candidate: do not enter nudge and do not
+  show a prepared-results CTA when the background cache has zero findings.
+
+First fix:
+
+- `cycle-complete` with zero findings should exit `working` via
+  `analysis-done`, and must not call the proactive-hints path.
+
+## Repair Plan
+
+### P0: Reproduce And Guard The Token Reload Issue
+
+Goal: token configuration must survive plugin reload and full Obsidian restart
+for a fresh vault and an upgraded vault.
+
+Implementation steps:
+
+1. Add a focused Settings/SecretStorage unit test that exercises the custom API
+   token modal save path, then reads back through `getAPITokenSecretId()` and
+   `getAPIToken()` after simulated reload settings.
+2. Add or update Obsidian smoke steps:
+   - choose provider;
+   - add token through Settings;
+   - close Settings;
+   - reload plugin;
+   - reopen Settings in the independent Settings window;
+   - verify the token is still configured without exposing the token value;
+   - run one low-cost provider health action if practical.
+3. If the secret id changes across reload, make `statisticsVaultId` creation
+   eagerly persisted before any API token editor can open.
+4. If the secret write succeeds but the UI looks empty, add an explicit
+   non-secret configured indicator such as "API token configured" and make the
+   edit button label stable.
+5. If SecretStorage behaves differently in Obsidian than mocks, keep the custom
+   modal but add a read-after-write check and a clear error Notice.
+
+Verification:
+
+- `npm test -- __tests__/settings.test.ts --runInBand`
+- `npx tsc -noEmit -skipLibCheck`
+- Settings-window smoke after `make deploy` and plugin reload.
+
+### P1: Productize Memory Local Storage Busy Recovery
+
+Goal: a local storage lock should be understandable and recoverable without
+exposing ordinary users to OPFS/SQLite details.
+
+Implementation steps:
+
+1. Keep the existing foreground safety boundary: no silent rebuild and no
+   fallback legacy cache load on lock.
+2. Add manual command de-duplication so repeated Settings/command clicks do not
+   stack prepare/update/reset/delete/status flows. First fix implemented:
+   `PluginManager.runManualMemoryAction()` covers command-palette and Settings
+   buttons, while `MemoryManager` keeps a prepare/update fallback guard.
+3. Add user-facing recovery copy for the normal Memory surface:
+   - "Memory is temporarily busy on this device."
+   - "Close other Obsidian windows for this vault, then try again."
+   - "This does not modify or delete notes."
+4. In advanced Memory controls, add an explicit `Retry local Memory recovery`
+   or improve `Show technical memory status` to show a user-action summary when
+   `lastErrorCode === "opfs-sahpool-locked"`.
+5. Ensure manual retry clears the last locked error after successful recovery.
+6. Add regression coverage for the user-facing message path, not only technical
+   stats.
+
+Verification:
+
+- Focused VSS locked tests.
+- `npm test -- __tests__/plugin-record-note.test.ts __tests__/settings.test.ts __tests__/memory-manager.test.ts --runInBand`
+- `npm test -- __tests__/memory-manager.test.ts __tests__/vss.test.ts --runInBand`
+- Obsidian smoke with two-window or hot-reload lock reproduction if feasible.
+
+### P1: Fix Empty Prepared Suggestions
+
+Goal: `View suggestions` should never lead to an empty `Recent Review` panel
+because of an empty background result.
+
+Implementation steps:
+
+1. In `BackgroundPreparationCoordinator.handleEvent`, treat
+   `cycle-complete` with `result.findings.length === 0` as `analysis-done`,
+   not `insights-ready`.
+2. In `ProactiveHints.onInsightsReady` or its call site, require a positive
+   finding count before setting pending hints.
+3. In `BubbleContent.buildNudgeContent`, hide or disable `View suggestions`
+   when findings are empty and show a normal empty-state CTA instead.
+4. In `handleExpandPanel("prepared")`, if prepared findings are empty, show a
+   short Notice and do not open a blank Recent Review panel.
+5. Consider renaming the prepared-results panel heading from `Recent Review` to
+   `Prepared Findings` / `已准备的发现` when the data source is background cache.
+
+Verification:
+
+- `npm test -- __tests__/pagelet-bubble-content.test.ts __tests__/pagelet-orchestrator.test.ts --runInBand`
+- Add a background-cycle unit test for empty findings producing no nudge.
+- Pagelet smoke: background result with findings, empty background result, and
+  reload-cleared cache.
+
+### P2: Make Background Preparation Observable
+
+Goal: users can tell whether background preparation is off, waiting, running,
+skipped, errored, or has prepared findings.
+
+Implementation steps:
+
+1. Extend `PreloadEngine.status()` with:
+   - `nextCycleAt`;
+   - last event type;
+   - last skip reason;
+   - last error category;
+   - last analyzed file count;
+   - cached finding count.
+2. Update `Pagelet: Show background preparation status` Notice to include
+   cached finding count now; add next run/reason/error in the fuller status
+   follow-up.
+3. Add a small Settings status row under Pagelet background preparation:
+   `Off / Waiting / Running / Last prepared / Cached findings`.
+4. On enabling background preparation, either:
+   - run one immediate bounded cycle after confirmation; or
+   - show "First preparation runs at HH:mm" and keep the current timer behavior.
+5. Keep cache session-only unless a separate privacy decision approves redacted
+   persistent metadata. Do not persist full provider output invisibly.
+
+Verification:
+
+- Unit tests for `PreloadEngine.status()`.
+- Settings render tests for the new status row.
+- Obsidian smoke: enable background preparation, inspect status before run,
+  after skipped no-changes, and after successful findings.
+
+### P2: Clarify Pagelet Resting/Sleeping Semantics
+
+Goal: the user can predict when Pagelet goes quiet.
+
+Implementation steps:
+
+1. Keep the four-state model: `resting`, `idle`, `working`, `nudge`.
+2. Add Settings/help copy: "Resting means no Markdown note activity for about
+   10 minutes. Editing a Markdown note wakes Pagelet back to idle."
+3. Add the idle/resting threshold to the Pagelet user guide and smoke checklist.
+4. Add or extend tests around `PageletOrchestrator.IDLE_TIMEOUT_MS` behavior if
+   the constant remains product-significant.
+
+Verification:
+
+- Existing Pet state tests.
+- Pagelet UI smoke with fake timers or app observation if practical.
+
+## Suggested Work Breakdown
+
+1. Settings token persistence repair and smoke.
+2. Empty prepared suggestions fix.
+3. Background preparation status observability.
+4. Memory local-storage busy recovery UX.
+5. Resting-state copy and docs.
+
+The first two are most likely to remove user-visible brokenness. The third
+turns background preparation from a hidden feature into something users can
+trust. The Memory lock item is important, but the low-level lock safety policy
+should not be loosened without evidence.
+
+## Decisions Needed
+
+1. On enabling Pagelet background preparation, should PA run an immediate first
+   preparation cycle, or only show the scheduled first-run time?
+2. Should background prepared results remain session-only, or may PA persist
+   redacted metadata such as last analyzed paths, finding count, and last run
+   time? Full provider output should stay non-persistent unless explicitly
+   saved by the user.
+3. Should the prepared-results panel keep the heading `Recent Review`, or be
+   renamed to `Prepared Findings` / `已准备的发现` to match the lightweight
+   background result?
+
+## Extra Reproduction Details To Request
+
+Before implementation, collect these details if possible:
+
+1. API token reload loss:
+   - Was the token added through the custom API-token modal or native keychain
+     picker?
+   - Was "reload" plugin reload, full Obsidian restart, or vault reopen?
+   - Which provider was configured?
+2. Memory locked:
+   - Was another Obsidian window open for the same vault?
+   - Did the lock appear after plugin reload, app restart, or Memory update?
+   - Did `Show technical memory status` recover or keep showing locked?
+3. Empty Recent Review:
+   - Was `View suggestions` opened from a green nudge state, from Bubble, or
+     from the Panel?
+   - Had background preparation status shown cached results before clicking?
+
+## Minimum Release Gate
+
+For a fix release touching these areas:
+
+- `npm test -- __tests__/settings.test.ts __tests__/memory-manager.test.ts __tests__/vss.test.ts __tests__/pagelet-bubble-content.test.ts __tests__/pagelet-orchestrator.test.ts __tests__/pagelet-preload-engine.test.ts --runInBand`
+- `npx tsc -noEmit -skipLibCheck`
+- `npm run lint`
+- `npm run build`
+- `git diff --check`
+- `make deploy`
+- Obsidian smoke for:
+  - Settings independent window token persistence across reload;
+  - Memory technical status and lock recovery copy;
+  - Pagelet background status before/after a cycle;
+  - `View suggestions` with findings and with empty findings;
+  - Pagelet resting after idle and wake after note activity.

--- a/src/locales/pagelet/en.json
+++ b/src/locales/pagelet/en.json
@@ -309,7 +309,8 @@
     "pagelet.preload.status.never": "never",
     "pagelet.preload.status.cacheYes": "yes",
     "pagelet.preload.status.cacheNo": "no",
-    "pagelet.preload.status.notice": "Background preparation: {state}\nLast: {last}\nBudget: {hourly}h / {daily}d\nCache: {cache}",
+    "pagelet.preload.status.notice": "Background preparation: {state}\nLast: {last}\nBudget: {hourly}h / {daily}d\nCache: {cache}\nFindings: {findings}",
+    "pagelet.preload.status.noCachedFindings": "No background suggestions are available yet.",
 
     "pagelet.periodicSummary.generating": "Generating summary…",
     "pagelet.periodicSummary.generatingForNotes": "Generating summary for {count} notes…",

--- a/src/locales/pagelet/zh.json
+++ b/src/locales/pagelet/zh.json
@@ -309,7 +309,8 @@
     "pagelet.preload.status.never": "从未",
     "pagelet.preload.status.cacheYes": "有",
     "pagelet.preload.status.cacheNo": "无",
-    "pagelet.preload.status.notice": "后台审阅准备：{state}\n上次：{last}\n预算：{hourly}h / {daily}d\n缓存：{cache}",
+    "pagelet.preload.status.notice": "后台审阅准备：{state}\n上次：{last}\n预算：{hourly}h / {daily}d\n缓存：{cache}\n发现：{findings}",
+    "pagelet.preload.status.noCachedFindings": "还没有可查看的后台建议。",
 
     "pagelet.periodicSummary.generating": "正在生成整理…",
     "pagelet.periodicSummary.generatingForNotes": "正在为 {count} 篇笔记生成整理…",

--- a/src/locales/plugin/en.json
+++ b/src/locales/plugin/en.json
@@ -193,6 +193,8 @@
     "plugin.memory.notice.readyNotesUnchanged": "Memory is ready. Your notes were not changed.",
     "plugin.memory.notice.unavailableAskNormally": "Memory is unavailable. You can still ask normally.",
     "plugin.memory.notice.notReadyPrepareFirst": "Memory is not ready. Prepare memory first.",
+    "plugin.memory.notice.prepareAlreadyRunning": "Memory preparation is already running.",
+    "plugin.memory.notice.actionAlreadyRunning": "A Memory action is already running.",
     "plugin.memory.notice.localCopyReset": "Local memory copy reset.",
     "plugin.memory.notice.needsPrepareAgain": "Memory needs to be prepared again on this device.",
     "plugin.memory.message.prepareFailedAnswerNow": "I could not prepare memory this time, so I answered normally.",

--- a/src/locales/plugin/en.json
+++ b/src/locales/plugin/en.json
@@ -193,7 +193,6 @@
     "plugin.memory.notice.readyNotesUnchanged": "Memory is ready. Your notes were not changed.",
     "plugin.memory.notice.unavailableAskNormally": "Memory is unavailable. You can still ask normally.",
     "plugin.memory.notice.notReadyPrepareFirst": "Memory is not ready. Prepare memory first.",
-    "plugin.memory.notice.prepareAlreadyRunning": "Memory preparation is already running.",
     "plugin.memory.notice.actionAlreadyRunning": "A Memory action is already running.",
     "plugin.memory.notice.localCopyReset": "Local memory copy reset.",
     "plugin.memory.notice.needsPrepareAgain": "Memory needs to be prepared again on this device.",

--- a/src/locales/plugin/zh.json
+++ b/src/locales/plugin/zh.json
@@ -193,6 +193,8 @@
     "plugin.memory.notice.readyNotesUnchanged": "Memory 已就绪。你的笔记未被修改。",
     "plugin.memory.notice.unavailableAskNormally": "Memory 不可用。你仍然可以正常提问。",
     "plugin.memory.notice.notReadyPrepareFirst": "Memory 尚未就绪。请先准备 Memory。",
+    "plugin.memory.notice.prepareAlreadyRunning": "Memory 正在准备中。",
+    "plugin.memory.notice.actionAlreadyRunning": "Memory 操作正在进行中。",
     "plugin.memory.notice.localCopyReset": "本地 Memory 副本已重置。",
     "plugin.memory.notice.needsPrepareAgain": "此设备需要重新准备 Memory。",
     "plugin.memory.message.prepareFailedAnswerNow": "这次无法准备 Memory，所以我已正常回答。",

--- a/src/locales/plugin/zh.json
+++ b/src/locales/plugin/zh.json
@@ -193,7 +193,6 @@
     "plugin.memory.notice.readyNotesUnchanged": "Memory 已就绪。你的笔记未被修改。",
     "plugin.memory.notice.unavailableAskNormally": "Memory 不可用。你仍然可以正常提问。",
     "plugin.memory.notice.notReadyPrepareFirst": "Memory 尚未就绪。请先准备 Memory。",
-    "plugin.memory.notice.prepareAlreadyRunning": "Memory 正在准备中。",
     "plugin.memory.notice.actionAlreadyRunning": "Memory 操作正在进行中。",
     "plugin.memory.notice.localCopyReset": "本地 Memory 副本已重置。",
     "plugin.memory.notice.needsPrepareAgain": "此设备需要重新准备 Memory。",

--- a/src/memory-manager.ts
+++ b/src/memory-manager.ts
@@ -174,6 +174,7 @@ export class MemoryManager {
     private readonly cleanupListeners: Array<() => void> = [];
     private lifecycleVersion = 0;
     private shuttingDown = false;
+    private manualCommandInFlight = false;
 
     constructor(host: MemoryHost, vss: VSS) {
         this.host = host;
@@ -429,22 +430,39 @@ export class MemoryManager {
     }
 
     async prepareFromCommand(): Promise<void> {
-        const plan = await this.getMaintenancePlan();
-        await this.runApprovedCommandPlan(plan);
+        await this.runManualCommand(async () => {
+            const plan = await this.getMaintenancePlan();
+            await this.runApprovedCommandPlan(plan);
+        });
     }
 
     async updateFromCommand(): Promise<void> {
-        const plan = await this.getMaintenancePlan();
-        const actionPlan: MemoryMaintenancePlan = plan.reason === "ready"
-            ? {
-                ...plan,
-                reason: "changed-notes",
-                action: "refresh",
-                notesLikelyToUpdate: plan.notesToCheck,
-                requiresApproval: true,
-            }
-            : plan;
-        await this.runApprovedCommandPlan(actionPlan);
+        await this.runManualCommand(async () => {
+            const plan = await this.getMaintenancePlan();
+            const actionPlan: MemoryMaintenancePlan = plan.reason === "ready"
+                ? {
+                    ...plan,
+                    reason: "changed-notes",
+                    action: "refresh",
+                    notesLikelyToUpdate: plan.notesToCheck,
+                    requiresApproval: true,
+                }
+                : plan;
+            await this.runApprovedCommandPlan(actionPlan);
+        });
+    }
+
+    private async runManualCommand(command: () => Promise<void>): Promise<void> {
+        if (this.manualCommandInFlight) {
+            new Notice(memoryT("plugin.memory.notice.actionAlreadyRunning"), 4000);
+            return;
+        }
+        this.manualCommandInFlight = true;
+        try {
+            await command();
+        } finally {
+            this.manualCommandInFlight = false;
+        }
     }
 
     private async runApprovedCommandPlan(plan: MemoryMaintenancePlan): Promise<void> {

--- a/src/pagelet/BackgroundPreparationCoordinator.ts
+++ b/src/pagelet/BackgroundPreparationCoordinator.ts
@@ -137,7 +137,7 @@ export class BackgroundPreparationCoordinator {
                 break;
 
             case "cycle-complete":
-                if (this.callbacks.onInsightsReady()) {
+                if (event.result.findings.length > 0 && this.callbacks.onInsightsReady()) {
                     this.callbacks.onPetTransition("insights-ready");
                 } else {
                     this.callbacks.onPetTransition("analysis-done");

--- a/src/pagelet/BubbleCoordinator.ts
+++ b/src/pagelet/BubbleCoordinator.ts
@@ -164,6 +164,11 @@ export class BubbleCoordinator {
 
         const locale = getPageletUiLanguage();
         const cachedFindings = this.preloadCache.getFindings();
+        if (cachedFindings.length === 0) {
+            const content = buildEmptyContent(this.buildQuickAccessCallbacks(bubbleView), locale);
+            bubbleView.show(content, anchorEl);
+            return;
+        }
         const findings: BubbleFinding[] = cachedFindings.map((f) => ({
             text: f.text,
             sourceLink: f.sourceFile,

--- a/src/pagelet/bubble/BubbleContent.ts
+++ b/src/pagelet/bubble/BubbleContent.ts
@@ -124,17 +124,25 @@ export function buildNudgeContent(
     callbacks: BubbleCallbacks,
     locale: PageletLocale = "en",
 ): BubbleContent {
-    const actions: BubbleAction[] = [
-        {
-            label: pageletT("pagelet.bubble.viewSuggestions", locale),
-            primary: true,
-            callback: () => callbacks.onExpandPanel("prepared"),
-        },
-        {
-            label: pageletT("pagelet.bubble.later", locale),
-            callback: () => callbacks.onDismiss(),
-        },
-    ];
+    const actions: BubbleAction[] = findings.length > 0
+        ? [
+            {
+                label: pageletT("pagelet.bubble.viewSuggestions", locale),
+                primary: true,
+                callback: () => callbacks.onExpandPanel("prepared"),
+            },
+            {
+                label: pageletT("pagelet.bubble.later", locale),
+                callback: () => callbacks.onDismiss(),
+            },
+        ]
+        : [
+            {
+                label: pageletT("pagelet.bubble.later", locale),
+                primary: true,
+                callback: () => callbacks.onDismiss(),
+            },
+        ];
 
     return {
         type: "nudge",

--- a/src/pagelet/orchestrator.ts
+++ b/src/pagelet/orchestrator.ts
@@ -849,6 +849,7 @@ export class PageletOrchestrator {
             hourly: status.budgetRemaining.hourly,
             daily: status.budgetRemaining.daily,
             cache: this.t(status.cacheHasResults ? "pagelet.preload.status.cacheYes" : "pagelet.preload.status.cacheNo"),
+            findings: status.cachedFindingCount,
         }), 8000);
     }
 
@@ -876,6 +877,11 @@ export class PageletOrchestrator {
         // Prepared findings come from the background cache and may not belong
         // to the active note. Keep them in the generic review layout rather
         // than presenting them as current-note analysis.
+        if (usePreparedFindings && this.preloadCache.getFindings().length === 0) {
+            new Notice(this.t("pagelet.preload.status.noCachedFindings"), 4000);
+            return;
+        }
+
         let panelFindings = usePreparedFindings
             ? []
             : this.sessionManager.currentAnalysisFindings();

--- a/src/pagelet/preload/PreloadCache.ts
+++ b/src/pagelet/preload/PreloadCache.ts
@@ -17,6 +17,10 @@ export class PreloadCache {
         return this.entry !== null;
     }
 
+    hasFindings(): boolean {
+        return this.getFindings().length > 0;
+    }
+
     clear(): void {
         this.entry = null;
     }

--- a/src/pagelet/preload/PreloadCache.ts
+++ b/src/pagelet/preload/PreloadCache.ts
@@ -17,10 +17,6 @@ export class PreloadCache {
         return this.entry !== null;
     }
 
-    hasFindings(): boolean {
-        return this.getFindings().length > 0;
-    }
-
     clear(): void {
         this.entry = null;
     }

--- a/src/pagelet/preload/PreloadEngine.ts
+++ b/src/pagelet/preload/PreloadEngine.ts
@@ -214,6 +214,7 @@ export class PreloadEngine {
         nextCycleAt: number | null;
         budgetRemaining: { hourly: number; daily: number };
         cacheHasResults: boolean;
+        cachedFindingCount: number;
         consecutiveErrors: number;
         adaptiveIntervalMs: number;
     } {
@@ -225,7 +226,8 @@ export class PreloadEngine {
                 ? (this.lastCycleAt ?? this.startedAt ?? Date.now()) + effectiveInterval
                 : null,
             budgetRemaining: this.budget.remaining(),
-            cacheHasResults: this.cache.has(),
+            cacheHasResults: this.cache.hasFindings(),
+            cachedFindingCount: this.cache.getFindings().length,
             consecutiveErrors: this.consecutiveErrors,
             adaptiveIntervalMs: effectiveInterval,
         };

--- a/src/pagelet/preload/PreloadEngine.ts
+++ b/src/pagelet/preload/PreloadEngine.ts
@@ -226,7 +226,7 @@ export class PreloadEngine {
                 ? (this.lastCycleAt ?? this.startedAt ?? Date.now()) + effectiveInterval
                 : null,
             budgetRemaining: this.budget.remaining(),
-            cacheHasResults: this.cache.hasFindings(),
+            cacheHasResults: this.cache.has(),
             cachedFindingCount: this.cache.getFindings().length,
             consecutiveErrors: this.consecutiveErrors,
             adaptiveIntervalMs: effectiveInterval,

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -14,7 +14,7 @@ import { SettingTab, type PluginManagerSettings, DEFAULT_SETTINGS, normalizeEnab
 import { OPERATIONS_AGENT_RUNTIME_ENABLED } from "./operations-agent-flags";
 import { LocalGraph } from './local-graph';
 import { openSettings, openSettingsTab } from './obsidian-internals';
-import { getVaultApiTokenId, hasSecretValue, icons } from './utils';
+import { KEYCHAIN_API_TOKEN_ID, getVaultApiTokenId, hasSecretValue, icons } from './utils';
 import { PluginsUpdater } from './plugin-manifest';
 import { ThemeUpdater } from './theme-manifest';
 import { monkeyPatchConsole } from './obsidian-hack/obsidian-mobile-debug';
@@ -229,6 +229,7 @@ export class PluginManager extends Plugin {
     statsManager: StatsManager | undefined;
     vss: VSS | null = null;
     memoryManager: MemoryManager | null = null;
+    private manualMemoryActionInFlight = false;
     chatHistoryStore: ChatHistoryStore | undefined;
     chatHistoryManager: ChatHistoryManager | undefined;
     private memoryExtractionScheduler: MemoryExtractionScheduler | null = null;
@@ -1138,8 +1139,12 @@ export class PluginManager extends Plugin {
                     requiresApproval: false,
                     canAnswerNow: true,
                 }),
-                prepareFromCommand: () => this.memoryManager?.prepareFromCommand() ?? Promise.resolve(),
-                updateFromCommand: () => this.memoryManager?.updateFromCommand() ?? Promise.resolve(),
+                prepareFromCommand: () => this.runManualMemoryAction(
+                    () => this.memoryManager?.prepareFromCommand() ?? Promise.resolve(),
+                ),
+                updateFromCommand: () => this.runManualMemoryAction(
+                    () => this.memoryManager?.updateFromCommand() ?? Promise.resolve(),
+                ),
                 showTechnicalStatus: () => void this.showTechnicalMemoryStatus(),
                 onStatusChanged: (listener) => this.onMemoryStatusChanged(listener),
             },
@@ -1993,6 +1998,19 @@ export class PluginManager extends Plugin {
         this.showTechnicalMemoryNotice(this.buildTechnicalMemoryStatusModel(stats, maintenance), 7000);
     }
 
+    async runManualMemoryAction(action: () => Promise<void>): Promise<void> {
+        if (this.manualMemoryActionInFlight) {
+            new Notice(this.t("plugin.memory.notice.actionAlreadyRunning"), 4000);
+            return;
+        }
+        this.manualMemoryActionInFlight = true;
+        try {
+            await action();
+        } finally {
+            this.manualMemoryActionInFlight = false;
+        }
+    }
+
     private getVssPerformanceNotice(chunkCount: number): string {
         if (chunkCount > 100_000) {
             return this.t("plugin.memory.diagnostics.performance100k");
@@ -2267,7 +2285,7 @@ export class PluginManager extends Plugin {
         if (!this.vss || !this.memoryManager) return false;
         if (this.getAISetupIssue() !== null) return false;
         if (!checking) {
-            void action().catch((error) => {
+            void this.runManualMemoryAction(action).catch((error) => {
                 this.log("Memory command failed", error);
                 new Notice(this.t("plugin.notice.memoryActionFailed"), 5000);
             });
@@ -2470,8 +2488,43 @@ export class PluginManager extends Plugin {
         return getVaultApiTokenId(this.settings.statisticsVaultId || "default-vault");
     }
 
+    private getAPITokenSecretCandidateIds(): string[] {
+        const currentId = this.getAPITokenSecretId();
+        const defaultScopedId = getVaultApiTokenId("default-vault");
+        return [currentId, defaultScopedId, KEYCHAIN_API_TOKEN_ID]
+            .filter((id, index, ids) => ids.indexOf(id) === index);
+    }
+
+    getConfiguredAPITokenSecret(): string | null {
+        const currentId = this.getAPITokenSecretId();
+        const currentToken = this.app.secretStorage.getSecret(currentId);
+        if (hasSecretValue(currentToken)) return currentToken;
+
+        for (const legacyId of this.getAPITokenSecretCandidateIds()) {
+            if (legacyId === currentId) continue;
+            const legacyToken = this.app.secretStorage.getSecret(legacyId);
+            if (!hasSecretValue(legacyToken)) continue;
+            return legacyToken;
+        }
+
+        return null;
+    }
+
+    setAPITokenSecret(value: string): void {
+        const currentId = this.getAPITokenSecretId();
+        this.app.secretStorage.setSecret(currentId, value);
+        if (value === "") {
+            for (const legacyId of this.getAPITokenSecretCandidateIds()) {
+                if (legacyId !== currentId) {
+                    this.app.secretStorage.setSecret(legacyId, "");
+                }
+            }
+        }
+        this.clearTokenCache();
+    }
+
     hasConfiguredAPIToken(): boolean {
-        return hasSecretValue(this.app.secretStorage.getSecret(this.getAPITokenSecretId()));
+        return hasSecretValue(this.getConfiguredAPITokenSecret());
     }
 
     getAISetupIssue(): string | null {
@@ -2491,7 +2544,7 @@ export class PluginManager extends Plugin {
         if (this.token !== "") {
             return this.token;
         }
-        const token = this.app.secretStorage.getSecret(this.getAPITokenSecretId());
+        const token = this.getConfiguredAPITokenSecret();
         if (!hasSecretValue(token)) {
             new Notice(this.t("plugin.notice.apiTokenNotConfigured"), 5000);
             return "";

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -2121,9 +2121,7 @@ export class SettingTab extends PluginSettingTab {
             .setDesc(this.t("plugin.settings.memory.technicalStatus.desc"))
             .addButton((button) => {
                 button.setButtonText(this.t("plugin.settings.memory.technicalStatus.button")).onClick(async () => {
-                    await plugin.runManualMemoryAction(async () => {
-                        await plugin.showTechnicalMemoryStatus();
-                    });
+                    await plugin.showTechnicalMemoryStatus();
                 });
             });
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -8,7 +8,7 @@ import { getDashScopeImageSynthesisUrl, isDashScopeCompatibleBaseURL } from "./a
 import { STAT_PREVIEW_TYPE } from './stats-view'
 import { normalizeStatisticsView } from './stats/stats-store'
 import { confirmUserAction } from "./confirm";
-import { getVaultScopedSecret, hasSecretValue } from "./utils";
+import { hasSecretValue } from "./utils";
 import {
     PAGELET_DEFAULTS,
     mergePageletSettings,
@@ -816,8 +816,9 @@ export class SettingTab extends PluginSettingTab {
         const plugin = this.plugin;
         const app = this.app;
         const secretId = plugin.getAPITokenSecretId();
-        const existing = getVaultScopedSecret(app.secretStorage, secretId) ?? "";
+        const existing = plugin.getConfiguredAPITokenSecret() ?? "";
         const translate = this.t.bind(this);
+        const rebuildProviderConfig = () => this.rebuildProviderConfig();
 
         class ApiTokenSecretModal extends Modal {
             onOpen(): void {
@@ -894,13 +895,13 @@ export class SettingTab extends PluginSettingTab {
                                     if (!confirmed) {
                                         return;
                                     }
-                                    app.secretStorage.setSecret(secretId, "");
-                                    plugin.clearTokenCache();
+                                    plugin.setAPITokenSecret("");
+                                    rebuildProviderConfig();
                                     this.close();
                                     return;
                                 }
-                                app.secretStorage.setSecret(secretId, value);
-                                plugin.clearTokenCache();
+                                plugin.setAPITokenSecret(value);
+                                rebuildProviderConfig();
                                 this.close();
                                 new Notice(translate("plugin.settings.apiToken.modal.saved"), 3000);
                             });
@@ -1568,15 +1569,14 @@ export class SettingTab extends PluginSettingTab {
             .setDesc(this.t("plugin.settings.ai.apiToken.desc"))
             .addComponent((el) => {
                 const secret = new SecretComponent(this.app, el);
-                const secretId = plugin.getAPITokenSecretId();
-                const existing = getVaultScopedSecret(this.app.secretStorage, secretId);
+                const existing = plugin.getConfiguredAPITokenSecret();
                 if (hasSecretValue(existing)) {
                     secret.setValue(existing);
                 }
                 this.renameSecretComponentLinkButton(el);
                 secret.onChange(async (value: string) => {
                     if (value === "") {
-                        const stored = getVaultScopedSecret(this.app.secretStorage, secretId);
+                        const stored = plugin.getConfiguredAPITokenSecret();
                         if (!hasSecretValue(stored)) {
                             return;
                         }
@@ -1592,12 +1592,10 @@ export class SettingTab extends PluginSettingTab {
                         }
                         // SecretStorage exposes only setSecret — writing "" is
                         // the equivalent of clearing the token.
-                        this.app.secretStorage.setSecret(secretId, "");
-                        plugin.clearTokenCache();
+                        plugin.setAPITokenSecret("");
                         return;
                     }
-                    this.app.secretStorage.setSecret(secretId, value);
-                    plugin.clearTokenCache();
+                    plugin.setAPITokenSecret(value);
                 });
                 return secret;
             });
@@ -2062,10 +2060,12 @@ export class SettingTab extends PluginSettingTab {
             .setDesc(this.t("plugin.settings.memory.update.desc"))
             .addButton((button) => {
                 button.setButtonText(this.t("plugin.settings.memory.update.button")).onClick(async () => {
-                    const memoryManager = getMemoryManager();
-                    if (!memoryManager) return;
-                    await memoryManager.updateFromCommand();
-                    await plugin.updateMemoryStatusBar();
+                    await plugin.runManualMemoryAction(async () => {
+                        const memoryManager = getMemoryManager();
+                        if (!memoryManager) return;
+                        await memoryManager.updateFromCommand();
+                        await plugin.updateMemoryStatusBar();
+                    });
                 });
             });
 
@@ -2074,9 +2074,11 @@ export class SettingTab extends PluginSettingTab {
             .setDesc(this.t("plugin.settings.memory.rebuild.desc"))
             .addButton((button) => {
                 button.setButtonText(this.t("plugin.settings.memory.rebuild.button")).onClick(async () => {
-                    const memoryManager = getMemoryManager();
-                    if (!memoryManager) return;
-                    await memoryManager.prepareFromCommand();
+                    await plugin.runManualMemoryAction(async () => {
+                        const memoryManager = getMemoryManager();
+                        if (!memoryManager) return;
+                        await memoryManager.prepareFromCommand();
+                    });
                 });
             });
 
@@ -2085,16 +2087,18 @@ export class SettingTab extends PluginSettingTab {
             .setDesc(this.t("plugin.settings.memory.reset.desc"))
             .addButton((button) => {
                 button.setButtonText(this.t("plugin.settings.memory.reset.button")).onClick(async () => {
-                    const confirmed = await confirmUserAction(this.app, {
-                        title: this.t("plugin.memory.confirm.reset.title"),
-                        message: this.t("plugin.memory.confirm.reset.message"),
-                        confirmText: this.t("plugin.memory.confirm.reset.confirm"),
+                    await plugin.runManualMemoryAction(async () => {
+                        const confirmed = await confirmUserAction(this.app, {
+                            title: this.t("plugin.memory.confirm.reset.title"),
+                            message: this.t("plugin.memory.confirm.reset.message"),
+                            confirmText: this.t("plugin.memory.confirm.reset.confirm"),
+                        });
+                        if (!confirmed) return;
+                        const vss = getVss();
+                        if (!vss) return;
+                        await vss.resetLocalIndex();
+                        await plugin.updateMemoryStatusBar();
                     });
-                    if (!confirmed) return;
-                    const vss = getVss();
-                    if (!vss) return;
-                    await vss.resetLocalIndex();
-                    await plugin.updateMemoryStatusBar();
                 });
             });
 
@@ -2103,10 +2107,12 @@ export class SettingTab extends PluginSettingTab {
             .setDesc(this.t("plugin.settings.memory.deleteCache.desc"))
             .addButton((button) => {
                 button.setButtonText(this.t("plugin.settings.memory.deleteCache.button")).onClick(async () => {
-                    const vss = getVss();
-                    if (!vss) return;
-                    await vss.cleanLegacyJsonCache();
-                    await plugin.updateMemoryStatusBar();
+                    await plugin.runManualMemoryAction(async () => {
+                        const vss = getVss();
+                        if (!vss) return;
+                        await vss.cleanLegacyJsonCache();
+                        await plugin.updateMemoryStatusBar();
+                    });
                 });
             });
 
@@ -2115,7 +2121,9 @@ export class SettingTab extends PluginSettingTab {
             .setDesc(this.t("plugin.settings.memory.technicalStatus.desc"))
             .addButton((button) => {
                 button.setButtonText(this.t("plugin.settings.memory.technicalStatus.button")).onClick(async () => {
-                    await plugin.showTechnicalMemoryStatus();
+                    await plugin.runManualMemoryAction(async () => {
+                        await plugin.showTechnicalMemoryStatus();
+                    });
                 });
             });
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -135,10 +135,6 @@ export const extractFile = async (zipBytes: ArrayBuffer, fileName: string) => {
 export const KEYCHAIN_API_TOKEN_ID = "pa-api-token";
 const SECRET_STORAGE_ID_MAX_LENGTH = 64;
 
-export interface SecretReader {
-    getSecret(id: string): string | null;
-}
-
 function hashSecretScope(value: string): string {
     let hash = 2166136261;
     for (let i = 0; i < value.length; i += 1) {
@@ -165,13 +161,6 @@ export function getVaultApiTokenId(vaultId?: string): string {
     const suffix = `-${hash}`;
     const head = scope.slice(0, maxScopeLength - suffix.length).replace(/-+$/g, "");
     return `${prefix}${head}${suffix}`;
-}
-
-export function getVaultScopedSecret(
-    secretStorage: SecretReader,
-    scopedId: string,
-): string | null {
-    return secretStorage.getSecret(scopedId);
 }
 
 export function hasSecretValue(secret: string | null): secret is string {


### PR DESCRIPTION
## Summary

This PR packages the v2.8.1 feedback fixes around Settings API token handling, manual Memory action contention, and Pagelet background prepared suggestions.

## Changes

- Add a shared manual Memory action guard and route Chat, Settings, and command-palette Memory entry points through it.
- Keep API token compatibility reads for legacy keychain IDs without mutating SecretStorage during read paths.
- Refresh the Settings token row after saving or clearing through the custom API token modal.
- Prevent empty Pagelet background results from entering the suggestions flow or opening an empty prepared-findings panel.
- Add cached finding count to the Pagelet background status notice.
- Add regression coverage and a v2.8.1 feedback repair plan.

## Validation

- `npm test -- __tests__/plugin-record-note.test.ts __tests__/settings.test.ts __tests__/memory-manager.test.ts __tests__/pagelet-background-preparation-coordinator.test.ts __tests__/pagelet-bubble-content.test.ts __tests__/pagelet-orchestrator.test.ts __tests__/pagelet-preload-engine.test.ts --runInBand`
- `npx tsc -noEmit -skipLibCheck`
- `npm run lint`
- `git diff --check`
- DOM injection scan for runtime `<style>`, `innerHTML`, and `outerHTML`
- `make deploy` with full Jest, lint, build, and deploy
- Obsidian test vault smoke: plugin reload, Chat view mount, Pagelet panel mount, and `dev:errors` clean
