### PR TITLE
refactor(vss): observe dirty updates before memory refresh

### DIFF
--- a/__tests__/memory-manager.test.ts
+++ b/__tests__/memory-manager.test.ts
@@ -421,6 +421,34 @@ describe('MemoryManager chat decisions', () => {
             jest.useRealTimers();
         }
     });
+
+    it('runs local verification under the default approval policy without auto flushing', async () => {
+        const plugin = createPlugin(createPlan());
+        plugin.vss.verifyPendingChanges.mockResolvedValue({
+            ...createOperationSummary({
+                dirtyConfirmed: 1,
+                verificationChecked: 1,
+            }),
+            markedDirty: 1,
+            hasMore: false,
+            bytesReadEstimate: 128,
+        });
+        plugin.vss.hasDirtyChanges.mockReturnValue(true);
+        const manager = createManager(plugin);
+        manager.startAutoMaintenance();
+        const flushSpy = jest.spyOn(manager, 'scheduleAutoFlush');
+
+        try {
+            await (manager as any).runBackgroundTask('verify', 'unit'); // eslint-disable-line @typescript-eslint/no-explicit-any
+
+            expect(plugin.vss.verifyPendingChanges).toHaveBeenCalledWith({ reason: 'unit' });
+            expect(plugin.notifyStatusChanged).toHaveBeenCalled();
+            expect(flushSpy).toHaveBeenCalledWith('verify', 0);
+            expect(plugin.vss.flush).not.toHaveBeenCalled();
+        } finally {
+            manager.stopAutoMaintenance();
+        }
+    });
 });
 
 describe('MemoryManager command decisions', () => {

--- a/__tests__/plugin-record-note.test.ts
+++ b/__tests__/plugin-record-note.test.ts
@@ -123,6 +123,7 @@ jest.mock('../src/memory-manager', () => ({
     MemoryManager: class {
         startAutoMaintenance() { }
         scheduleAutoFlush() { }
+        scheduleVerify() { }
         prepareFromCommand() { }
     },
 }));
@@ -174,6 +175,54 @@ import { PageletDetailView } from '../src/pagelet/tab';
 const createTFile = (path: string): TFile => {
     const FileCtor = TFile as unknown as { new(path: string): TFile };
     return new FileCtor(path);
+};
+
+const createTFileWithStat = (path: string, stat: { mtime: number; size: number; ctime?: number }): TFile => {
+    const file = createTFile(path) as TFile & { stat: { mtime: number; size: number; ctime: number } };
+    file.stat = {
+        ctime: stat.mtime,
+        ...stat,
+    };
+    return file;
+};
+
+const createVaultEventDispatchHarness = () => {
+    const vaultHandlers = new Map<string, (...args: unknown[]) => Promise<void>>();
+    const workspaceHandlers = new Map<string, (...args: unknown[]) => Promise<void>>();
+    const plugin = Object.create(PluginManager.prototype) as any; // eslint-disable-line @typescript-eslint/no-explicit-any
+    plugin.registerEvent = jest.fn();
+    plugin.app = {
+        vault: {
+            on: jest.fn((name: string, callback: (...args: unknown[]) => Promise<void>) => {
+                vaultHandlers.set(name, callback);
+                return { name, callback };
+            }),
+        },
+        workspace: {
+            on: jest.fn((name: string, callback: (...args: unknown[]) => Promise<void>) => {
+                workspaceHandlers.set(name, callback);
+                return { name, callback };
+            }),
+        },
+    };
+    plugin.pageletRuntime = null;
+    plugin.memoryExtractionScheduler = { handleVaultEvent: jest.fn() };
+    plugin.vss = {
+        observeChangedFile: jest.fn(async () => ({ kind: 'ignored' })),
+        handleRename: jest.fn(async () => true),
+        handleDelete: jest.fn(async () => undefined),
+        handleActiveLeafChange: jest.fn(async () => undefined),
+        handleFileOpen: jest.fn(async () => false),
+        getMaintenanceState: jest.fn(() => ({ dirtyCount: 0, verificationPending: 0 })),
+    };
+    plugin.memoryManager = {
+        scheduleAutoFlush: jest.fn(),
+        scheduleVerify: jest.fn(),
+    };
+    plugin.debouncedStatusBarUpdate = jest.fn();
+    plugin.memoryEventGateStartedAt = 1_000_000;
+    (plugin as { registerVaultEventDispatch: () => void }).registerVaultEventDispatch();
+    return { plugin, vaultHandlers, workspaceHandlers };
 };
 
 const collectModalTexts = (node: MockModalContentRecord): string[] => [
@@ -295,6 +344,91 @@ const createPluginHarness = ({
 
     return { plugin, vault, openFile, createdFiles, secretStorage };
 };
+
+describe('Memory vault event dispatch', () => {
+    it('ignores startup replay modify bursts with old mtimes before observing Memory changes', async () => {
+        const nowSpy = jest.spyOn(Date, 'now').mockReturnValue(1_010_000);
+        try {
+            const { plugin, vaultHandlers } = createVaultEventDispatchHarness();
+            const modify = vaultHandlers.get('modify');
+            expect(modify).toBeDefined();
+
+            for (let index = 0; index < 1000; index++) {
+                const file = createTFileWithStat(`old-${index}.md`, { mtime: 900_000, size: index + 1 });
+                await modify?.(file);
+            }
+
+            expect(plugin.memoryExtractionScheduler.handleVaultEvent).toHaveBeenCalledTimes(1000);
+            expect(plugin.vss.observeChangedFile).not.toHaveBeenCalled();
+            expect(plugin.memoryManager.scheduleAutoFlush).not.toHaveBeenCalled();
+            expect(plugin.memoryManager.scheduleVerify).not.toHaveBeenCalled();
+            expect(plugin.debouncedStatusBarUpdate).not.toHaveBeenCalled();
+        } finally {
+            nowSpy.mockRestore();
+        }
+    });
+
+    it('observes fresh startup-window edits and schedules verification candidates', async () => {
+        const nowSpy = jest.spyOn(Date, 'now').mockReturnValue(1_010_000);
+        try {
+            const { plugin, vaultHandlers } = createVaultEventDispatchHarness();
+            plugin.vss.observeChangedFile.mockResolvedValueOnce({
+                kind: 'verify-candidate',
+                path: 'fresh.md',
+                reason: 'vault-modify',
+            });
+            const file = createTFileWithStat('fresh.md', { mtime: 1_010_000, size: 42 });
+
+            await vaultHandlers.get('modify')?.(file);
+
+            expect(plugin.vss.observeChangedFile).toHaveBeenCalledWith(file, 'vault-modify');
+            expect(plugin.memoryManager.scheduleVerify).toHaveBeenCalledWith('vault-modify');
+            expect(plugin.memoryManager.scheduleAutoFlush).not.toHaveBeenCalled();
+        } finally {
+            nowSpy.mockRestore();
+        }
+    });
+
+    it('schedules auto flush only for confirmed dirty observations', async () => {
+        const nowSpy = jest.spyOn(Date, 'now').mockReturnValue(1_010_000);
+        try {
+            const { plugin, vaultHandlers } = createVaultEventDispatchHarness();
+            plugin.vss.observeChangedFile.mockResolvedValueOnce({
+                kind: 'confirmed-dirty',
+                path: 'created.md',
+                reason: 'missing-index-record',
+            });
+            const file = createTFileWithStat('created.md', { mtime: 1_010_000, size: 42 });
+
+            await vaultHandlers.get('create')?.(file);
+
+            expect(plugin.vss.observeChangedFile).toHaveBeenCalledWith(file, 'vault-create');
+            expect(plugin.memoryManager.scheduleAutoFlush).toHaveBeenCalledWith('vault-create');
+            expect(plugin.debouncedStatusBarUpdate).toHaveBeenCalled();
+            expect(plugin.memoryManager.scheduleVerify).not.toHaveBeenCalled();
+        } finally {
+            nowSpy.mockRestore();
+        }
+    });
+
+    it('keeps rename and delete handling outside the startup replay gate', async () => {
+        const nowSpy = jest.spyOn(Date, 'now').mockReturnValue(1_010_000);
+        try {
+            const { plugin, vaultHandlers } = createVaultEventDispatchHarness();
+            const file = createTFileWithStat('renamed.md', { mtime: 900_000, size: 42 });
+
+            await vaultHandlers.get('rename')?.(file, 'old.md');
+            await vaultHandlers.get('delete')?.(file);
+
+            expect(plugin.vss.handleRename).toHaveBeenCalledWith(file, 'old.md');
+            expect(plugin.memoryManager.scheduleAutoFlush).toHaveBeenCalledWith('vault-rename');
+            expect(plugin.vss.handleDelete).toHaveBeenCalledWith(file);
+            expect(plugin.debouncedStatusBarUpdate).toHaveBeenCalledTimes(2);
+        } finally {
+            nowSpy.mockRestore();
+        }
+    });
+});
 
 describe('record note creation', () => {
     it('creates root-level record notes without trying to create the vault root folder', async () => {

--- a/__tests__/plugin-record-note.test.ts
+++ b/__tests__/plugin-record-note.test.ts
@@ -346,7 +346,7 @@ const createPluginHarness = ({
 };
 
 describe('Memory vault event dispatch', () => {
-    it('ignores startup replay modify bursts with old mtimes before observing Memory changes', async () => {
+    it('observes startup replay modify bursts without scheduling metadata-match maintenance', async () => {
         const nowSpy = jest.spyOn(Date, 'now').mockReturnValue(1_010_000);
         try {
             const { plugin, vaultHandlers } = createVaultEventDispatchHarness();
@@ -359,7 +359,10 @@ describe('Memory vault event dispatch', () => {
             }
 
             expect(plugin.memoryExtractionScheduler.handleVaultEvent).toHaveBeenCalledTimes(1000);
-            expect(plugin.vss.observeChangedFile).not.toHaveBeenCalled();
+            expect(plugin.vss.observeChangedFile).toHaveBeenCalledTimes(1000);
+            expect(plugin.vss.observeChangedFile).toHaveBeenLastCalledWith(expect.any(TFile), 'vault-modify', 'metadata-drift', {
+                verifyMatchingMetadata: false,
+            });
             expect(plugin.memoryManager.scheduleAutoFlush).not.toHaveBeenCalled();
             expect(plugin.memoryManager.scheduleVerify).not.toHaveBeenCalled();
             expect(plugin.debouncedStatusBarUpdate).not.toHaveBeenCalled();
@@ -381,7 +384,9 @@ describe('Memory vault event dispatch', () => {
 
             await vaultHandlers.get('modify')?.(file);
 
-            expect(plugin.vss.observeChangedFile).toHaveBeenCalledWith(file, 'vault-modify');
+            expect(plugin.vss.observeChangedFile).toHaveBeenCalledWith(file, 'vault-modify', 'metadata-drift', {
+                verifyMatchingMetadata: true,
+            });
             expect(plugin.memoryManager.scheduleVerify).toHaveBeenCalledWith('vault-modify');
             expect(plugin.memoryManager.scheduleAutoFlush).not.toHaveBeenCalled();
         } finally {
@@ -402,7 +407,9 @@ describe('Memory vault event dispatch', () => {
 
             await vaultHandlers.get('create')?.(file);
 
-            expect(plugin.vss.observeChangedFile).toHaveBeenCalledWith(file, 'vault-create');
+            expect(plugin.vss.observeChangedFile).toHaveBeenCalledWith(file, 'vault-create', 'metadata-drift', {
+                verifyMatchingMetadata: false,
+            });
             expect(plugin.memoryManager.scheduleAutoFlush).toHaveBeenCalledWith('vault-create');
             expect(plugin.debouncedStatusBarUpdate).toHaveBeenCalled();
             expect(plugin.memoryManager.scheduleVerify).not.toHaveBeenCalled();

--- a/__tests__/vss.test.ts
+++ b/__tests__/vss.test.ts
@@ -1175,6 +1175,147 @@ describe('VSS SQLite/WASM lifecycle', () => {
         });
     });
 
+    it('ignores matching vault change observations and clears stale dirty journal entries', async () => {
+        const now = Date.now();
+        const file = createTFile('same.md', { size: 10, mtime: now, ctime: now }, 'md', 'same.md');
+        const { plugin, vssStateStore } = createPlugin({
+            getVSSFiles: jest.fn(() => [file]),
+        });
+        const vss = new VSS(plugin, 'cache');
+        const index = new FakeVectorIndex();
+        attachReadyIndex(vss, index);
+        index.records.set('same.md', {
+            path: 'same.md',
+            contentHash: 'same-hash',
+            mtime: now,
+            size: 10,
+            status: 'ready',
+            updatedAt: now,
+        });
+        const dirtyMap = (vss as any).dirty as Map<string, DirtyTimestamps>; // eslint-disable-line @typescript-eslint/no-explicit-any
+        dirtyMap.set('same.md', { first: now - 60_000, last: now - 60_000 });
+        await vssStateStore.setDirtyJournal(new Map(dirtyMap));
+
+        const observation = await vss.observeChangedFile(file, 'vault-modify');
+
+        expect(observation).toEqual({ kind: 'ignored', path: 'same.md', reason: 'metadata-match' });
+        expect(dirtyMap.has('same.md')).toBe(false);
+        expect(await vssStateStore.getDirtyJournal()).toEqual(new Map());
+        expect(index.upsertFile).not.toHaveBeenCalled();
+    });
+
+    it('keeps newer confirmed dirty state when metadata still matches the indexed record', async () => {
+        const now = Date.now();
+        const file = createTFile('same.md', { size: 10, mtime: now, ctime: now }, 'md', 'same.md');
+        const { plugin, vssStateStore } = createPlugin({
+            getVSSFiles: jest.fn(() => [file]),
+        });
+        const vss = new VSS(plugin, 'cache');
+        const index = new FakeVectorIndex();
+        attachReadyIndex(vss, index);
+        index.records.set('same.md', {
+            path: 'same.md',
+            contentHash: 'old-hash',
+            mtime: now,
+            size: 10,
+            status: 'ready',
+            updatedAt: now - 5_000,
+        });
+        const dirtyMap = (vss as any).dirty as Map<string, DirtyTimestamps>; // eslint-disable-line @typescript-eslint/no-explicit-any
+        dirtyMap.set('same.md', { first: now, last: now });
+        await vssStateStore.setDirtyJournal(new Map(dirtyMap));
+
+        const observation = await vss.observeChangedFile(file, 'vault-modify');
+
+        expect(observation).toEqual({ kind: 'confirmed-dirty', path: 'same.md', reason: 'already-dirty' });
+        expect(dirtyMap.has('same.md')).toBe(true);
+        expect((await vssStateStore.getDirtyJournal()).has('same.md')).toBe(true);
+    });
+
+    it('marks missing indexed records as confirmed dirty from vault observations', async () => {
+        const now = Date.now();
+        const file = createTFile('created.md', { size: 11, mtime: now, ctime: now }, 'md', 'created.md');
+        const { plugin, vssStateStore } = createPlugin({
+            getVSSFiles: jest.fn(() => [file]),
+        });
+        const vss = new VSS(plugin, 'cache');
+        const index = new FakeVectorIndex();
+        attachReadyIndex(vss, index);
+
+        const observation = await vss.observeChangedFile(file, 'vault-create');
+
+        const dirtyMap = (vss as any).dirty as Map<string, DirtyTimestamps>; // eslint-disable-line @typescript-eslint/no-explicit-any
+        expect(observation).toEqual({ kind: 'confirmed-dirty', path: 'created.md', reason: 'missing-index-record' });
+        expect(dirtyMap.has('created.md')).toBe(true);
+        expect((await vssStateStore.getDirtyJournal()).has('created.md')).toBe(true);
+    });
+
+    it('queues metadata drift observations for verification without dirty journal persistence', async () => {
+        const now = Date.now();
+        const file = createTFile('changed.md', { size: 99, mtime: now + 5, ctime: now }, 'md', 'changed.md');
+        const { plugin, vssStateStore } = createPlugin({
+            getVSSFiles: jest.fn(() => [file]),
+        });
+        const vss = new VSS(plugin, 'cache');
+        const index = new FakeVectorIndex();
+        attachReadyIndex(vss, index);
+        index.records.set('changed.md', {
+            path: 'changed.md',
+            contentHash: 'old-hash',
+            mtime: now,
+            size: 10,
+            status: 'ready',
+            updatedAt: now,
+        });
+
+        const observation = await vss.observeChangedFile(file, 'vault-modify');
+        const plan = await vss.getMemoryReadiness();
+
+        const dirtyMap = (vss as any).dirty as Map<string, DirtyTimestamps>; // eslint-disable-line @typescript-eslint/no-explicit-any
+        const verifyQueue = (vss as any).verifyQueue as Map<string, unknown>; // eslint-disable-line @typescript-eslint/no-explicit-any
+        expect(observation).toEqual({ kind: 'verify-candidate', path: 'changed.md', reason: 'vault-modify' });
+        expect(dirtyMap.has('changed.md')).toBe(false);
+        expect(verifyQueue.has('changed.md')).toBe(true);
+        expect(await vssStateStore.getDirtyJournal()).toEqual(new Map());
+        expect(plan.reason).toBe('ready');
+        expect(plan.verificationPending).toBe(1);
+    });
+
+    it('keeps matching startup-scale observations out of dirty journal and embedding', async () => {
+        const now = Date.now();
+        const files = Array.from({ length: 1000 }, (_, index) =>
+            createTFile(`same-${index}.md`, { size: index + 1, mtime: now + index, ctime: now }, 'md', `same-${index}.md`)
+        );
+        const { plugin, vssStateStore } = createPlugin({
+            getVSSFiles: jest.fn(() => files),
+        });
+        const vss = new VSS(plugin, 'cache');
+        const index = new FakeVectorIndex();
+        attachReadyIndex(vss, index);
+        for (const file of files) {
+            index.records.set(file.path, {
+                path: file.path,
+                contentHash: `hash-${file.path}`,
+                mtime: file.stat.mtime,
+                size: file.stat.size,
+                status: 'ready',
+                updatedAt: now,
+            });
+        }
+        const createEmbeddings = (vss as any).aiUtils.createEmbeddings as jest.MockedFunction<(...args: unknown[]) => Promise<unknown>>; // eslint-disable-line @typescript-eslint/no-explicit-any
+
+        for (const file of files) {
+            await vss.observeChangedFile(file, 'vault-modify');
+        }
+
+        const dirtyMap = (vss as any).dirty as Map<string, DirtyTimestamps>; // eslint-disable-line @typescript-eslint/no-explicit-any
+        const verifyQueue = (vss as any).verifyQueue as Map<string, unknown>; // eslint-disable-line @typescript-eslint/no-explicit-any
+        expect(dirtyMap.size).toBe(0);
+        expect(verifyQueue.size).toBe(0);
+        expect(await vssStateStore.getDirtyJournal()).toEqual(new Map());
+        expect(createEmbeddings).not.toHaveBeenCalled();
+    });
+
     it('queues metadata drift for verification while marking new notes dirty', async () => {
         const now = Date.now();
         const changed = createTFile('changed.md', { size: 10, mtime: now + 5, ctime: now }, 'md', 'changed.md');
@@ -1217,6 +1358,34 @@ describe('VSS SQLite/WASM lifecycle', () => {
         expect(persistedDirty.has('created.md')).toBe(true);
         expect(persistedDirty.has('changed.md')).toBe(false);
         expect(mockAdapter.write).not.toHaveBeenCalledWith('cache/dirty.json', expect.any(String));
+    });
+
+    it('clears stale dirty journal entries during reconcile when indexed metadata already matches', async () => {
+        const now = Date.now();
+        const file = createTFile('clean.md', { size: 10, mtime: now, ctime: now }, 'md', 'clean.md');
+        const { plugin, vssStateStore } = createPlugin({
+            getVSSFiles: jest.fn(() => [file]),
+        });
+        const vss = new VSS(plugin, 'cache');
+        const index = new FakeVectorIndex();
+        attachReadyIndex(vss, index);
+        index.records.set('clean.md', {
+            path: 'clean.md',
+            contentHash: 'clean-hash',
+            mtime: now,
+            size: 10,
+            status: 'ready',
+            updatedAt: now,
+        });
+        const dirtyMap = (vss as any).dirty as Map<string, DirtyTimestamps>; // eslint-disable-line @typescript-eslint/no-explicit-any
+        dirtyMap.set('clean.md', { first: now - 60_000, last: now - 60_000 });
+        await vssStateStore.setDirtyJournal(new Map(dirtyMap));
+
+        const summary = await vss.reconcileLocalFiles({ verifyHashLimit: 0 });
+
+        expect(summary.unchanged).toBe(1);
+        expect(dirtyMap.has('clean.md')).toBe(false);
+        expect(await vssStateStore.getDirtyJournal()).toEqual(new Map());
     });
 
     it('does not keep empty or blank missing records dirty during reconcile', async () => {

--- a/__tests__/vss.test.ts
+++ b/__tests__/vss.test.ts
@@ -1175,7 +1175,7 @@ describe('VSS SQLite/WASM lifecycle', () => {
         });
     });
 
-    it('ignores matching vault change observations and clears stale dirty journal entries', async () => {
+    it('ignores matching startup-replay observations and clears stale dirty journal entries', async () => {
         const now = Date.now();
         const file = createTFile('same.md', { size: 10, mtime: now, ctime: now }, 'md', 'same.md');
         const { plugin, vssStateStore } = createPlugin({
@@ -1196,10 +1196,43 @@ describe('VSS SQLite/WASM lifecycle', () => {
         dirtyMap.set('same.md', { first: now - 60_000, last: now - 60_000 });
         await vssStateStore.setDirtyJournal(new Map(dirtyMap));
 
-        const observation = await vss.observeChangedFile(file, 'vault-modify');
+        const observation = await vss.observeChangedFile(file, 'vault-modify', 'metadata-drift', {
+            verifyMatchingMetadata: false,
+        });
 
         expect(observation).toEqual({ kind: 'ignored', path: 'same.md', reason: 'metadata-match' });
         expect(dirtyMap.has('same.md')).toBe(false);
+        expect(await vssStateStore.getDirtyJournal()).toEqual(new Map());
+        expect(index.upsertFile).not.toHaveBeenCalled();
+    });
+
+    it('queues matching vault modify observations for verification without dirty journal persistence', async () => {
+        const now = Date.now();
+        const file = createTFile('same.md', { size: 10, mtime: now, ctime: now }, 'md', 'same.md');
+        const { plugin, vssStateStore } = createPlugin({
+            getVSSFiles: jest.fn(() => [file]),
+        });
+        const vss = new VSS(plugin, 'cache');
+        const index = new FakeVectorIndex();
+        attachReadyIndex(vss, index);
+        index.records.set('same.md', {
+            path: 'same.md',
+            contentHash: 'same-hash',
+            mtime: now,
+            size: 10,
+            status: 'ready',
+            updatedAt: now,
+        });
+
+        const observation = await vss.observeChangedFile(file, 'vault-modify', 'metadata-drift', {
+            verifyMatchingMetadata: true,
+        });
+
+        const dirtyMap = (vss as any).dirty as Map<string, DirtyTimestamps>; // eslint-disable-line @typescript-eslint/no-explicit-any
+        const verifyQueue = (vss as any).verifyQueue as Map<string, unknown>; // eslint-disable-line @typescript-eslint/no-explicit-any
+        expect(observation).toEqual({ kind: 'verify-candidate', path: 'same.md', reason: 'vault-modify' });
+        expect(dirtyMap.has('same.md')).toBe(false);
+        expect(verifyQueue.has('same.md')).toBe(true);
         expect(await vssStateStore.getDirtyJournal()).toEqual(new Map());
         expect(index.upsertFile).not.toHaveBeenCalled();
     });
@@ -1305,7 +1338,9 @@ describe('VSS SQLite/WASM lifecycle', () => {
         const createEmbeddings = (vss as any).aiUtils.createEmbeddings as jest.MockedFunction<(...args: unknown[]) => Promise<unknown>>; // eslint-disable-line @typescript-eslint/no-explicit-any
 
         for (const file of files) {
-            await vss.observeChangedFile(file, 'vault-modify');
+            await vss.observeChangedFile(file, 'vault-modify', 'metadata-drift', {
+                verifyMatchingMetadata: false,
+            });
         }
 
         const dirtyMap = (vss as any).dirty as Map<string, DirtyTimestamps>; // eslint-disable-line @typescript-eslint/no-explicit-any

--- a/docs/vss-dirty-state-optimization-plan.md
+++ b/docs/vss-dirty-state-optimization-plan.md
@@ -34,7 +34,7 @@ Dirty state is split across existing runtime structures:
 ```mermaid
 flowchart TD
   A[Vault create/modify] --> B{Startup replay old mtime?}
-  B -->|yes| C[Ignore; startup reconcile remains source of truth]
+  B -->|yes| C[Light observation; ignore only metadata match]
   B -->|no| D{Indexed record exists?}
   D -->|no| E[confirmed-dirty]
   D -->|yes| F{mtime + size match?}
@@ -49,22 +49,23 @@ flowchart TD
 ## Implementation Contract
 
 - `vault.create` and `vault.modify` call `VSS.observeChangedFile()` instead of marking dirty directly.
-- During the first 90 seconds after plugin load, `create`/`modify` events whose file `mtime` is more than 5 seconds older than plugin load are treated as startup replay and ignored for Memory maintenance.
+- During the first 90 seconds after plugin load, `create`/`modify` events whose file `mtime` is more than 5 seconds older than plugin load are treated as startup replay, but they still pass through lightweight observation so missing indexed records and metadata drift are not lost. Metadata-matching startup replay events are ignored for Memory maintenance.
 - Startup replay filtering does not apply to `rename` or `delete`.
 - Memory extraction still receives vault events unless the existing Pagelet self-write guard returns early.
-- `verifyQueue` remains process-local and is reconstructed by startup/resume/periodic reconcile.
+- `verifyQueue` remains process-local and is reconstructed by startup/resume/periodic reconcile. Vault-event verification may run under the default approval policy because it only performs local hash/metadata checks; provider-backed refresh still requires confirmed dirty state and the existing approval/auto-refresh policy.
 - The dirty journal persists only confirmed dirty paths.
 - Reconcile clears stale dirty entries when indexed metadata already matches the current vault file.
 - Manual Update, Rebuild, Reset, and force refresh behavior remains unchanged.
 
 ## Acceptance Tests
 
-- Metadata-matching `create`/`modify` observations return `ignored`, write no dirty journal, and do not call embeddings.
+- Metadata-matching startup replay observations return `ignored`, write no dirty journal, and do not call embeddings.
+- Non-replay `vault.modify` observations are treated as strong write evidence and enter verification even when metadata still matches.
 - Missing indexed records become `confirmed-dirty` and persist in dirty journal.
 - Metadata drift becomes `verify-candidate`, keeps Memory readiness `ready`, and does not persist dirty state.
 - Hash verification promotes candidates to dirty only when cleaned content hash changes.
 - Reconcile removes stale dirty journal entries for files whose indexed metadata already matches current vault metadata.
-- Startup replay bursts with old mtimes do not call VSS change observation and do not schedule auto flush.
+- Startup replay bursts with old mtimes call VSS change observation but do not schedule maintenance for metadata matches or auto flush until a missing record or real content drift is confirmed.
 - Fresh edits inside the startup window still enter the normal observation path.
 - Rename/delete continue to use the existing maintenance paths.
 

--- a/docs/vss-dirty-state-optimization-plan.md
+++ b/docs/vss-dirty-state-optimization-plan.md
@@ -1,0 +1,81 @@
+# VSS Dirty State Optimization Plan
+
+## Purpose
+
+Memory dirty state should mean "confirmed work that needs a Memory refresh", not "an Obsidian event happened". A real vault incident on 2026-06-24 showed `dirtyCount` and the persisted dirty journal both near the full vault size, while most sampled files already matched the local Memory index by `contentHash`, `mtime`, and `size`. The likely trigger was Obsidian startup/cache replay emitting many `create`/`modify` events for old files.
+
+The optimization separates lightweight change candidates from confirmed dirty paths without adding a new persistent state table.
+
+## Current Failure Mode
+
+```mermaid
+flowchart TD
+  A[Obsidian startup/cache replay] --> B[vault create/modify events]
+  B --> C[markDirtyIfEligible]
+  C --> D[dirty map]
+  D --> E[dirty journal in IndexedDB]
+  E --> F[restart hydrates same dirty journal]
+  F --> G[Memory status: changed-notes]
+  G --> H[background flush slowly proves most files unchanged]
+```
+
+This is safe but noisy and inefficient: false dirty paths become durable local state, trigger user-visible changed-notes, and rely on refresh/flush to clean themselves up.
+
+## Target State
+
+Dirty state is split across existing runtime structures:
+
+| State | Backing store | Meaning | User-visible status |
+| --- | --- | --- | --- |
+| Clean | SQLite file record | Current file metadata/hash is already represented | Ready |
+| Verify candidate | In-memory `verifyQueue` | Metadata drift or suspicious event needs hash verification | Ready |
+| Confirmed dirty | In-memory `dirty` + IndexedDB dirty journal | Missing index record or hash-confirmed content change needs refresh | Changed notes |
+
+```mermaid
+flowchart TD
+  A[Vault create/modify] --> B{Startup replay old mtime?}
+  B -->|yes| C[Ignore; startup reconcile remains source of truth]
+  B -->|no| D{Indexed record exists?}
+  D -->|no| E[confirmed-dirty]
+  D -->|yes| F{mtime + size match?}
+  F -->|yes| G[clean / clear stale dirty]
+  F -->|no| H[verify-candidate]
+  H --> I{hash changed?}
+  I -->|no| J[sync metadata, stay Ready]
+  I -->|yes| E
+  E --> K[existing flush/update path]
+```
+
+## Implementation Contract
+
+- `vault.create` and `vault.modify` call `VSS.observeChangedFile()` instead of marking dirty directly.
+- During the first 90 seconds after plugin load, `create`/`modify` events whose file `mtime` is more than 5 seconds older than plugin load are treated as startup replay and ignored for Memory maintenance.
+- Startup replay filtering does not apply to `rename` or `delete`.
+- Memory extraction still receives vault events unless the existing Pagelet self-write guard returns early.
+- `verifyQueue` remains process-local and is reconstructed by startup/resume/periodic reconcile.
+- The dirty journal persists only confirmed dirty paths.
+- Reconcile clears stale dirty entries when indexed metadata already matches the current vault file.
+- Manual Update, Rebuild, Reset, and force refresh behavior remains unchanged.
+
+## Acceptance Tests
+
+- Metadata-matching `create`/`modify` observations return `ignored`, write no dirty journal, and do not call embeddings.
+- Missing indexed records become `confirmed-dirty` and persist in dirty journal.
+- Metadata drift becomes `verify-candidate`, keeps Memory readiness `ready`, and does not persist dirty state.
+- Hash verification promotes candidates to dirty only when cleaned content hash changes.
+- Reconcile removes stale dirty journal entries for files whose indexed metadata already matches current vault metadata.
+- Startup replay bursts with old mtimes do not call VSS change observation and do not schedule auto flush.
+- Fresh edits inside the startup window still enter the normal observation path.
+- Rename/delete continue to use the existing maintenance paths.
+
+## Validation
+
+Focused verification:
+
+- `npm test -- __tests__/vss.test.ts --runInBand`
+- `npm test -- __tests__/memory-manager.test.ts --runInBand`
+- `npm test -- __tests__/plugin-record-note.test.ts --runInBand`
+- `npm run build`
+- `git diff --check`
+
+Runtime smoke for release confidence should deploy to the repo-local test vault and inspect Memory status through Obsidian CLI or app evidence before claiming real Obsidian validation.

--- a/docs/vss-embedding-refresh.md
+++ b/docs/vss-embedding-refresh.md
@@ -9,7 +9,7 @@
 
 ## 当前关键机制
 
-- **事件改造**：`vault.create` / `vault.modify` 标记脏文件，`vault.rename` 删除旧 path 并标记新 path，`vault.delete` 删除本地索引记录；事件本身不直接计算 embedding。
+- **事件改造**：`vault.create` / `vault.modify` 先观察本地索引 metadata：启动期旧 mtime replay 与 metadata 已匹配的事件会被忽略，metadata drift 进入 verify queue，缺失 indexed record 才标记 dirty；`vault.rename` 删除旧 path 并标记新 path，`vault.delete` 删除本地索引记录；事件本身不直接计算 embedding。
 - **首次授权后的自动维护**：用户确认并成功 prepare/update Memory 后，`memoryApprovalPolicy` 升级为 `auto-refresh-after-prepare`；后续 changed notes 在 durable SQLite/WASM ready 时由后台 reconcile/verify/refresh 维护，Chat 不再等待 refresh。
 - **本地静默状态**：后台自动维护只写设备本地 SQLite/WASM OPFS Memory index，并把 marker 与 dirty journal 写入本地 IndexedDB state store；默认不在 vault 中创建 `vss-index-state/`、`manifest.json` 或 `vss-cache/dirty.json`。如果 IndexedDB 暂时打不开，VSS 先把 marker/dirty state 保留在进程内，后续 update/status 路径重试并落盘。
 - **静默窗口 + 最长延迟**：后台 refresh 保留 `quietWindow=30s` 和 `maxDelay=10min`，避免用户连续编辑时反复计算。
@@ -111,7 +111,7 @@ DOM 更新节流到约 350ms，`retrying` 和 `ready` 会立即显示。
 
 ## 触发流程
 
-1. **发现变化**：`create` / `modify` 标 dirty，`rename` 删除旧 path 并标 dirty，新旧设备同步差异由 reconcile 扫描补齐。
+1. **发现变化**：`create` / `modify` 先走 observation gate；启动期旧 mtime replay 与 metadata match 不进入 dirty，metadata mismatch 进入 verify queue，missing record 标 dirty；`rename` 删除旧 path 并标 dirty，新旧设备同步差异由 reconcile 扫描补齐。
 2. **触发维护**：Chat auto policy、vault event quiet window、启动/prepare/resume/周期 reconcile，或手动 Update。
 3. **reconcile metadata**：批量读取 indexed records，与 vault 文件列表对比；missing indexed path 删除，新文件标 dirty，metadata mismatch / rolling candidate 进入 verify queue。
 4. **verify queue**：按桌面/移动端预算读取少量文件计算 hash；hash 相同只同步 `vss_files` metadata，hash 变化才标 dirty。
@@ -137,5 +137,6 @@ DOM 更新节流到约 350ms，`retrying` 和 `ready` 会立即显示。
 - auto policy + durable ready + changed notes 时 Chat 不弹确认、不等待 refresh，会调度后台 reconcile/verify/flush。
 - 非 durable 或不可用状态下不会执行自动写入，并会提示后台更新不可用。
 - reconcile 能发现新增、deleted indexed path，并把 durable ready 下的 metadata mismatch/rolling candidate 放入 verify queue。verify 只有在 hash 真实变化时才标 dirty。metadata-only 漂移不会让 Memory 进入 needs update，也不会把聊天入口的 brain 状态变成 changed-notes。
+- vault event observation 能过滤启动期旧 mtime replay 和 metadata 已匹配的 `create`/`modify` 事件；只有 missing indexed record 或 hash-confirmed 变化会写入 dirty journal。
 - 大 vault reconcile 的 `hasMore` 能在多轮扫描后收敛，避免持续每秒扫描。
 - verify budget 能限制单轮读取文件数、读取字节估算和主线程占用；dirty 清理使用 epoch/stamp 防止 verify 误清除更新的 modify 事件。

--- a/docs/vss-embedding-refresh.md
+++ b/docs/vss-embedding-refresh.md
@@ -9,7 +9,7 @@
 
 ## 当前关键机制
 
-- **事件改造**：`vault.create` / `vault.modify` 先观察本地索引 metadata：启动期旧 mtime replay 与 metadata 已匹配的事件会被忽略，metadata drift 进入 verify queue，缺失 indexed record 才标记 dirty；`vault.rename` 删除旧 path 并标记新 path，`vault.delete` 删除本地索引记录；事件本身不直接计算 embedding。
+- **事件改造**：`vault.create` / `vault.modify` 先观察本地索引 metadata：启动期旧 mtime replay 仍会经过轻量 observation，只有 metadata 已匹配的 replay 被忽略；普通 `vault.modify` 即使 metadata 匹配也会进入 verify queue，metadata drift 进入 verify queue，缺失 indexed record 才标记 dirty；`vault.rename` 删除旧 path 并标记新 path，`vault.delete` 删除本地索引记录；事件本身不直接计算 embedding。
 - **首次授权后的自动维护**：用户确认并成功 prepare/update Memory 后，`memoryApprovalPolicy` 升级为 `auto-refresh-after-prepare`；后续 changed notes 在 durable SQLite/WASM ready 时由后台 reconcile/verify/refresh 维护，Chat 不再等待 refresh。
 - **本地静默状态**：后台自动维护只写设备本地 SQLite/WASM OPFS Memory index，并把 marker 与 dirty journal 写入本地 IndexedDB state store；默认不在 vault 中创建 `vss-index-state/`、`manifest.json` 或 `vss-cache/dirty.json`。如果 IndexedDB 暂时打不开，VSS 先把 marker/dirty state 保留在进程内，后续 update/status 路径重试并落盘。
 - **静默窗口 + 最长延迟**：后台 refresh 保留 `quietWindow=30s` 和 `maxDelay=10min`，避免用户连续编辑时反复计算。
@@ -26,7 +26,7 @@
 
 ## Reconcile 与后台调度
 
-`MemoryManager.startAutoMaintenance()` 在插件加载后启动轻量调度器，并在 unload 时清理 timers 和 window/document listeners。自动任务只在 `memoryApprovalPolicy === "auto-refresh-after-prepare"` 且 VSS durable backend ready 时运行。
+`MemoryManager.startAutoMaintenance()` 在插件加载后启动轻量调度器，并在 unload 时清理 timers 和 window/document listeners。自动 reconcile/refresh 只在 `memoryApprovalPolicy === "auto-refresh-after-prepare"` 且 VSS durable backend ready 时运行；verify 是本地 hash/metadata 检查，可在默认确认策略下运行，确认 dirty 后仍走既有确认/自动刷新策略。
 
 `stopAutoMaintenance()` 会让 in-flight background task 和 prepare flow 进入 shutdown-aware 模式：已经返回的长任务不会再 schedule retry/reconcile、刷新 Memory status bar 或弹出成功/失败 Notice。这样插件升级或热重载时，不会由旧实例继续触发 UI 更新或新的 embedding 工作。
 
@@ -36,7 +36,7 @@
 - 首次成功 prepare/update 后 5 秒。
 - window focus 或 `visibilitychange` 恢复 visible 后 30 秒。
 - 每 60 分钟一次周期 reconcile。
-- Chat 遇到 `changed-notes` 且 auto policy 可用时立即排队 reconcile、verify 和 auto flush；如果只是 pending verification，聊天前最多做一个小预算 fast verify，移动端使用更小的 1-file 预算。
+- Chat 遇到 `changed-notes` 且 auto policy 可用时立即排队 reconcile、verify 和 auto flush；如果只是 pending verification，聊天前最多做一个小预算 fast verify，移动端使用更小的 1-file 预算。Vault-event verify 也可在后台做同类本地检查，以免进程内候选在 reload 前丢失。
 
 `reconcileLocalFiles()` 优先用 `VectorIndex.listFileRecords()` 批量读取 indexed metadata，减少逐文件 worker round-trip。单轮最多处理 2000 个 metadata 项，每批 250 个文件后 `sleep(0)` 让出主线程；未完成时通过 `hasMore` 继续排队。metadata mismatch 不在 reconcile 内读文件 hash，而是进入 verify queue，所以文件只是 mtime/size 漂移时不会把 Memory status 变成 changed-notes。周期 reconcile 还会按游标把最多 50 个 metadata 未变化文件加入 verify queue，用于发现跨设备同步中 mtime/size 未变化但内容变化的少数情况。
 
@@ -111,7 +111,7 @@ DOM 更新节流到约 350ms，`retrying` 和 `ready` 会立即显示。
 
 ## 触发流程
 
-1. **发现变化**：`create` / `modify` 先走 observation gate；启动期旧 mtime replay 与 metadata match 不进入 dirty，metadata mismatch 进入 verify queue，missing record 标 dirty；`rename` 删除旧 path 并标 dirty，新旧设备同步差异由 reconcile 扫描补齐。
+1. **发现变化**：`create` / `modify` 先走 observation gate；启动期旧 mtime replay 只在 metadata match 时忽略，metadata mismatch 进入 verify queue，missing record 标 dirty；普通 `vault.modify` 即使 metadata match 也进入 verify queue；`rename` 删除旧 path 并标 dirty，新旧设备同步差异由 reconcile 扫描补齐。
 2. **触发维护**：Chat auto policy、vault event quiet window、启动/prepare/resume/周期 reconcile，或手动 Update。
 3. **reconcile metadata**：批量读取 indexed records，与 vault 文件列表对比；missing indexed path 删除，新文件标 dirty，metadata mismatch / rolling candidate 进入 verify queue。
 4. **verify queue**：按桌面/移动端预算读取少量文件计算 hash；hash 相同只同步 `vss_files` metadata，hash 变化才标 dirty。

--- a/docs/vss-sqlite-wasm-architecture.md
+++ b/docs/vss-sqlite-wasm-architecture.md
@@ -53,7 +53,7 @@ flowchart TB
   User["用户"] --> ChatUI["Chat UI\nAsk / Answer now / Cancel"]
   User --> Commands["普通命令\nPrepare Memory / Open Chat"]
   User --> Advanced["高级入口\nAdvanced memory controls"]
-  Vault["Vault events\ncreate / modify / rename / delete"] --> MemoryManager
+  Vault["Vault events\ncreate / modify observation\nrename / delete"] --> MemoryManager
   Resume["Startup / focus / visibility / periodic"] --> MemoryManager
   ChatUI --> MemoryManager["MemoryManager\n检查 readiness\n显示确认弹窗"]
   Commands --> MemoryManager
@@ -367,7 +367,7 @@ flowchart LR
 
 发现变化的来源：
 
-1. Vault events：`create` / `modify` 标记 dirty，`rename` 删除旧 path 并标记新 path，`delete` 直接删除 indexed row。
+1. Vault events：`create` / `modify` 先走 observation gate；启动期旧 mtime replay 与 metadata 已匹配的事件保持 clean，metadata mismatch 只加入 verify queue，缺失 indexed record 才进入 confirmed dirty。`rename` 删除旧 path 并标记新 path，`delete` 直接删除 indexed row。
 2. Reconcile scan：启动后 60s、prepare 后 5s、focus/visibility 恢复后 30s、每 60min 扫描一次 vault 当前文件和 indexed records；durable ready 下的 metadata mismatch 只加入 verify queue，不触发 Memory update。
 3. Verify queue：file-open、metadata mismatch 和 rolling candidate 会按预算读取文件计算 hash；hash 相同只同步 `vss_files` metadata，hash 变化才标 dirty。verify queue 是 VSS ready 之上的内存态 overlay，不是 `VectorIndexStatus`。
 4. Rolling hash verify：周期 reconcile 每小时最多把 50 个 metadata 未变化文件加入 verify queue，按游标轮转，用于发现跨设备同步中 mtime/size 未变化但内容变化的情况。

--- a/docs/vss-sqlite-wasm-architecture.md
+++ b/docs/vss-sqlite-wasm-architecture.md
@@ -367,9 +367,9 @@ flowchart LR
 
 发现变化的来源：
 
-1. Vault events：`create` / `modify` 先走 observation gate；启动期旧 mtime replay 与 metadata 已匹配的事件保持 clean，metadata mismatch 只加入 verify queue，缺失 indexed record 才进入 confirmed dirty。`rename` 删除旧 path 并标记新 path，`delete` 直接删除 indexed row。
+1. Vault events：`create` / `modify` 先走 observation gate；启动期旧 mtime replay 仍会轻量观察，只有 metadata 已匹配的 replay 保持 clean，metadata mismatch 只加入 verify queue，缺失 indexed record 才进入 confirmed dirty。普通 `vault.modify` 即使 metadata 已匹配也会进入 verify queue，避免真实写入信号在 reload 前丢失。`rename` 删除旧 path 并标记新 path，`delete` 直接删除 indexed row。
 2. Reconcile scan：启动后 60s、prepare 后 5s、focus/visibility 恢复后 30s、每 60min 扫描一次 vault 当前文件和 indexed records；durable ready 下的 metadata mismatch 只加入 verify queue，不触发 Memory update。
-3. Verify queue：file-open、metadata mismatch 和 rolling candidate 会按预算读取文件计算 hash；hash 相同只同步 `vss_files` metadata，hash 变化才标 dirty。verify queue 是 VSS ready 之上的内存态 overlay，不是 `VectorIndexStatus`。
+3. Verify queue：vault modify、file-open、metadata mismatch 和 rolling candidate 会按预算读取文件计算 hash；hash 相同只同步 `vss_files` metadata，hash 变化才标 dirty。verify queue 是 VSS ready 之上的内存态 overlay，不是 `VectorIndexStatus`；vault-event verify 可以在默认确认策略下执行，因为它只做本地 hash/metadata 检查，不调用 embedding provider。
 4. Rolling hash verify：周期 reconcile 每小时最多把 50 个 metadata 未变化文件加入 verify queue，按游标轮转，用于发现跨设备同步中 mtime/size 未变化但内容变化的情况。
 
 预算控制：

--- a/src/memory-manager.ts
+++ b/src/memory-manager.ts
@@ -252,7 +252,7 @@ export class MemoryManager {
 
     scheduleVerify(reason: string, delayMs = this.getVerifyDelayMs()): void {
         if (!this.started) return;
-        if (!this.isAutoPolicyEnabled()) return;
+        if (!this.isMemoryEnabled()) return;
         if (this.verifyTimer) {
             clearPlatformTimeout(this.verifyTimer);
         }
@@ -498,7 +498,12 @@ export class MemoryManager {
         const lifecycleToken = this.lifecycleVersion;
         try {
             if (!this.isLifecycleCurrent(lifecycleToken)) return;
-            if (!await this.canRunAutoMaintenance()) return;
+            if (kind === "verify") {
+                if (!this.isMemoryEnabled()) return;
+                if (!await this.canRunLocalMaintenance()) return;
+            } else if (!await this.canRunAutoMaintenance()) {
+                return;
+            }
             if (!this.isLifecycleCurrent(lifecycleToken)) return;
             if (kind === "flush") {
                 const summary = await this.vss.flush({
@@ -612,8 +617,12 @@ export class MemoryManager {
     }
 
     private isAutoPolicyEnabled(): boolean {
-        return this.host.settings.memoryEnabled
+        return this.isMemoryEnabled()
             && this.host.settings.memoryApprovalPolicy === AUTO_MEMORY_POLICY;
+    }
+
+    private isMemoryEnabled(): boolean {
+        return this.host.settings.memoryEnabled;
     }
 
     private isLifecycleCurrent(token: number): boolean {

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -729,11 +729,10 @@ export class PluginManager extends Plugin {
     }
 
     private async handleMemoryVaultChange(file: TFile, reason: "vault-create" | "vault-modify"): Promise<void> {
-        if (this.isLikelyStartupReplayMemoryEvent(file)) {
-            return;
-        }
-
-        const observation = await this.vss?.observeChangedFile(file, reason);
+        const isStartupReplay = this.isLikelyStartupReplayMemoryEvent(file);
+        const observation = await this.vss?.observeChangedFile(file, reason, "metadata-drift", {
+            verifyMatchingMetadata: reason === "vault-modify" && !isStartupReplay,
+        });
         if (!observation) return;
         if (observation.kind === "confirmed-dirty") {
             this.memoryManager?.scheduleAutoFlush(reason);

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -88,6 +88,8 @@ import type { ChatHost } from './chat/ChatHost';
 const CALLOUT_MANAGER_PLUGIN_ID = 'callout-manager';
 const CALLOUT_MANAGER_READY_TIMEOUT_MS = 2000;
 const CALLOUT_MANAGER_READY_POLL_MS = 50;
+const MEMORY_STARTUP_EVENT_REPLAY_WINDOW_MS = 90_000;
+const MEMORY_STARTUP_EVENT_MTIME_GRACE_MS = 5_000;
 interface TechnicalMemoryDetail {
     label: string;
     value: string;
@@ -270,6 +272,7 @@ export class PluginManager extends Plugin {
     private resizeDebounceTimer: TimeoutHandle | null = null;
     private phase3Handle: PlatformTimeoutHandle | null = null;
     private unloading = false;
+    private memoryEventGateStartedAt = Date.now();
     private debouncedStatusBarUpdate = debounce(() => {
         void this.updateMemoryStatusBar();
     }, 300, true);
@@ -283,6 +286,7 @@ export class PluginManager extends Plugin {
     }
 
     async onload() {
+        this.memoryEventGateStartedAt = Date.now();
         await this.loadSettings();
 
         // 迁移旧版本设置
@@ -651,7 +655,7 @@ export class PluginManager extends Plugin {
     }
 
     private registerVaultEventDispatch(): void {
-        // VSS lifecycle events mark local state dirty; approved Memory can then maintain itself in the background.
+        // VSS lifecycle events observe possible local changes; approved Memory can then maintain itself in the background.
         this.registerEvent(
             this.app.vault.on("create", async (file) => {
                 if (file instanceof TFile) {
@@ -664,10 +668,7 @@ export class PluginManager extends Plugin {
                         return;
                     }
                     this.memoryExtractionScheduler?.handleVaultEvent(file, "vault-create");
-                    if (await this.vss?.markDirtyIfEligible(file)) {
-                        this.memoryManager?.scheduleAutoFlush("vault-create");
-                        this.debouncedStatusBarUpdate();
-                    }
+                    await this.handleMemoryVaultChange(file, "vault-create");
                 }
             })
         );
@@ -683,10 +684,7 @@ export class PluginManager extends Plugin {
                         return;
                     }
                     this.memoryExtractionScheduler?.handleVaultEvent(file, "vault-modify");
-                    if (await this.vss?.markDirtyIfEligible(file)) {
-                        this.memoryManager?.scheduleAutoFlush("vault-modify");
-                        this.debouncedStatusBarUpdate();
-                    }
+                    await this.handleMemoryVaultChange(file, "vault-modify");
                 }
             })
         );
@@ -728,6 +726,33 @@ export class PluginManager extends Plugin {
                 }
             })
         );
+    }
+
+    private async handleMemoryVaultChange(file: TFile, reason: "vault-create" | "vault-modify"): Promise<void> {
+        if (this.isLikelyStartupReplayMemoryEvent(file)) {
+            return;
+        }
+
+        const observation = await this.vss?.observeChangedFile(file, reason);
+        if (!observation) return;
+        if (observation.kind === "confirmed-dirty") {
+            this.memoryManager?.scheduleAutoFlush(reason);
+            this.debouncedStatusBarUpdate();
+        } else if (observation.kind === "verify-candidate") {
+            this.memoryManager?.scheduleVerify(reason);
+        }
+    }
+
+    private isLikelyStartupReplayMemoryEvent(file: TFile): boolean {
+        if (typeof this.memoryEventGateStartedAt !== "number" || !Number.isFinite(this.memoryEventGateStartedAt)) {
+            this.memoryEventGateStartedAt = Date.now();
+        }
+        if (Date.now() - this.memoryEventGateStartedAt > MEMORY_STARTUP_EVENT_REPLAY_WINDOW_MS) {
+            return false;
+        }
+        const mtime = file.stat?.mtime;
+        return typeof mtime === "number"
+            && mtime < this.memoryEventGateStartedAt - MEMORY_STARTUP_EVENT_MTIME_GRACE_MS;
     }
 
     private syncPageletRuntime(): void {

--- a/src/vss.ts
+++ b/src/vss.ts
@@ -1,7 +1,7 @@
 /* Copyright 2023 edonyzpc */
 
 export { buildFtsQuery, VSS } from "./vss/vss-core";
-export type { VSSRefreshStatus } from "./vss/vss-core";
+export type { VSSChangeObservation, VSSRefreshStatus } from "./vss/vss-core";
 export type {
     VSSFlushOptions,
     VSSOperationOptions,

--- a/src/vss/vss-core.ts
+++ b/src/vss/vss-core.ts
@@ -98,6 +98,10 @@ function vssT(key: string, params?: Readonly<Record<string, string | number>>, f
 }
 
 export type VSSRefreshStatus = 'updated' | 'unchanged' | 'metadata-synced' | 'removed' | 'skipped';
+export type VSSChangeObservation =
+    | { kind: "ignored"; path?: string; reason?: string }
+    | { kind: "verify-candidate"; path: string; reason: string }
+    | { kind: "confirmed-dirty"; path: string; reason: string };
 
 export type {
     VSSFlushOptions,
@@ -435,29 +439,50 @@ export class VSS {
         return changed;
     }
 
-    async markDirtyIfIndexedMetadataChanged(file: TFile | null): Promise<boolean> {
-        if (this.disposed) return false;
-        if (!(file instanceof TFile)) return false;
-        if (!this.isEligible(file)) return false;
+    async observeChangedFile(
+        file: TAbstractFile | null,
+        reason = "vault-event",
+        verifyReason: VerifyReason = "metadata-drift",
+    ): Promise<VSSChangeObservation> {
+        if (this.disposed) return { kind: "ignored", reason: "disposed" };
+        if (!(file instanceof TFile)) return { kind: "ignored", reason: "not-file" };
+        if (!this.isEligible(file)) return { kind: "ignored", path: file.path, reason: "ineligible" };
         await this.initialize();
-        if (!this.index || this.status !== "ready") {
-            return false;
+        if (!this.index || !await this.isDurableReady()) {
+            return { kind: "ignored", path: file.path, reason: "not-ready" };
         }
 
         const record = await this.index.getFileRecord(file.path);
-        if (record && record.mtime === file.stat.mtime && record.size === file.stat.size) {
-            return false;
-        }
-
         if (!record) {
             const changed = this.markDirtyPath(file.path);
             if (changed) {
                 await this.persistDirtyJournal();
             }
-            return changed;
+            return { kind: "confirmed-dirty", path: file.path, reason: "missing-index-record" };
         }
 
-        return this.enqueueVerifyPath(file, record, "file-open");
+        if (record.mtime === file.stat.mtime && record.size === file.stat.size) {
+            this.verifyQueue.delete(file.path);
+            if (this.clearStaleDirtyForSyncedRecord(file.path, record)) {
+                await this.persistDirtyJournal();
+            }
+            if (this.dirty.has(file.path)) {
+                return { kind: "confirmed-dirty", path: file.path, reason: "already-dirty" };
+            }
+            return { kind: "ignored", path: file.path, reason: "metadata-match" };
+        }
+
+        if (this.dirty.has(file.path)) {
+            return { kind: "confirmed-dirty", path: file.path, reason: "already-dirty" };
+        }
+
+        this.enqueueVerifyPath(file, record, verifyReason);
+        return { kind: "verify-candidate", path: file.path, reason };
+    }
+
+    async markDirtyIfIndexedMetadataChanged(file: TFile | null): Promise<boolean> {
+        const observation = await this.observeChangedFile(file, "file-open", "file-open");
+        return observation.kind !== "ignored";
     }
 
     async handleDelete(file: TFile): Promise<void> {
@@ -1009,6 +1034,9 @@ export class VSS {
                         summary.verificationQueued++;
                     }
                 } else {
+                    if (this.clearStaleDirtyForSyncedRecord(file.path, record)) {
+                        dirtyChanged = true;
+                    }
                     summary.unchanged++;
                 }
                 await maybeYield();
@@ -1808,6 +1836,14 @@ export class VSS {
         if (!dirty) return false;
         const currentStamp = dirty.epoch ?? dirty.last;
         if (stamp === undefined || currentStamp !== stamp) return false;
+        return this.dirty.delete(path);
+    }
+
+    private clearStaleDirtyForSyncedRecord(path: string, record: VSSFileRecord): boolean {
+        const dirty = this.dirty.get(path);
+        if (!dirty) return false;
+        const lastDirtyAt = dirty.last ?? dirty.first ?? 0;
+        if (lastDirtyAt > record.updatedAt) return false;
         return this.dirty.delete(path);
     }
 

--- a/src/vss/vss-core.ts
+++ b/src/vss/vss-core.ts
@@ -103,6 +103,10 @@ export type VSSChangeObservation =
     | { kind: "verify-candidate"; path: string; reason: string }
     | { kind: "confirmed-dirty"; path: string; reason: string };
 
+interface VSSChangeObservationOptions {
+    verifyMatchingMetadata?: boolean;
+}
+
 export type {
     VSSFlushOptions,
     VSSOperationOptions,
@@ -443,6 +447,7 @@ export class VSS {
         file: TAbstractFile | null,
         reason = "vault-event",
         verifyReason: VerifyReason = "metadata-drift",
+        options: VSSChangeObservationOptions = {},
     ): Promise<VSSChangeObservation> {
         if (this.disposed) return { kind: "ignored", reason: "disposed" };
         if (!(file instanceof TFile)) return { kind: "ignored", reason: "not-file" };
@@ -453,6 +458,7 @@ export class VSS {
         }
 
         const record = await this.index.getFileRecord(file.path);
+        const verifyMatchingMetadata = options.verifyMatchingMetadata ?? reason === "vault-modify";
         if (!record) {
             const changed = this.markDirtyPath(file.path);
             if (changed) {
@@ -462,13 +468,17 @@ export class VSS {
         }
 
         if (record.mtime === file.stat.mtime && record.size === file.stat.size) {
-            this.verifyQueue.delete(file.path);
             if (this.clearStaleDirtyForSyncedRecord(file.path, record)) {
                 await this.persistDirtyJournal();
             }
             if (this.dirty.has(file.path)) {
                 return { kind: "confirmed-dirty", path: file.path, reason: "already-dirty" };
             }
+            if (verifyMatchingMetadata) {
+                this.enqueueVerifyPath(file, record, verifyReason);
+                return { kind: "verify-candidate", path: file.path, reason };
+            }
+            this.verifyQueue.delete(file.path);
             return { kind: "ignored", path: file.path, reason: "metadata-match" };
         }
 


### PR DESCRIPTION
## Summary

- Adds a startup vault-event replay gate so old modify events emitted shortly after Obsidian startup do not mark unchanged Memory notes dirty.
- Routes create/modify events through `VSS.observeChangedFile`, separating ignored metadata matches, verification candidates, and confirmed dirty notes.
- Clears stale dirty journal entries when indexed metadata is already synced, with new Jest coverage and VSS docs for the observation-based flow.

## Impact

This should reduce unnecessary Memory refresh work after startup or vault replay bursts while preserving auto-refresh for confirmed new or changed notes. Metadata-only drift is queued for verification instead of immediately forcing embedding refresh.

## Validation

- `git diff --check origin/master...origin/refactor/vss-dirty-update`
- `npm test -- --runInBand __tests__/vss.test.ts __tests__/plugin-record-note.test.ts`
- `npx tsc -noEmit -skipLibCheck`